### PR TITLE
Add configuration to NerdDice

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,34 @@ Or install it yourself as:
     $ gem install nerd_dice
 
 ## Usage
+### Configuration
+You can customize the behavior of NerdDice via a configuration block as below or by assigning an individual property via the ```NerdDice.configuration.property = value``` syntax \(where ```property``` is the config property and ```value``` is the value you want to assign\)\. The available configuration options as well as their defaults, if applicable, are listed in the example configuration block below:
+
+```ruby
+NerdDice.configure do | config|
+
+  # number of ability scores to place in an ability score array
+  config.ability_score_array_size = 6
+
+  # randomization technique options are:
+    # :securerandom => Uses SecureRandom.rand(). Good entropy, medium speed.
+    # :rand => Uses default rand(). Poor entropy, fast speed.
+      # (Seed is shared with other processes. Too predictable)
+    # :random_new_once => Uses Random.new() and calls rand()
+      # Medium entropy, fastest speed. (Performs the best under speed benchmark)
+    # :random_new_interval => Uses Random.new(), but refreshes periodically
+    #  by creating a new seed at configured interval.
+      # Speed varies, entropy varies. See below
+    # :randomized => Uses a random choice of the :securerandom, :rand, and :random_new_interval options above
+  config.randomization_technique = :random_new_once # fastest option, but don't use if running a casino
+
+  # Number of iterations to use on :random_new_interval technique before refreshing the seed
+    # 1 very slow and heavy pressure on processor and memory but very high entropy
+    # 1000 would refresh the object every 1000 times you call rand()
+  config.new_random_interval = 50 # refresh the seed every 50 times you roll
+end
+```
+
 ### Rolling a number of dice and adding a bonus
 ```ruby
 # roll a single d4

--- a/lib/nerd_dice.rb
+++ b/lib/nerd_dice.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "nerd_dice/version"
+require "nerd_dice/configuration"
 # Nerd dice allows you to roll polyhedral dice and add bonuses as you would in
 # a tabletop roleplaying game. You can choose to roll multiple dice and keep a
 # specified number of dice such as rolling 4d6 and dropping the lowest for
@@ -22,6 +23,16 @@ require "nerd_dice/version"
 #   The bonus in the options hash must be an Integer or it will be ignored
 module NerdDice
   class Error < StandardError; end
+
+  RANDOMIZATION_TECHNIQUES = %i[securerandom rand random_new_once random_new_interval randomized].freeze
+
+  def self.configure
+    yield configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
 
   ############################
   # total_dice class method

--- a/lib/nerd_dice/configuration.rb
+++ b/lib/nerd_dice/configuration.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module NerdDice
+  # The NerdDice::Configuration class allows you to configure and customize the
+  # options of the NerdDice gem to suit your specific needs. You can specify
+  # properties like the randomization technique used by the gem, the number of
+  # ability scores in an ability score array, etc. See the README for a list of
+  # configurable attributes.
+  #
+  # Usage:
+  #   The configuration can either be set via a configure block:
+  #   <tt>NerdDice.configure do |config|
+  #         config.randomization_technique = :random_new_interval
+  #         config.new_random_interval     = 100
+  #       end
+  #   </tt>
+  #
+  #   You can also set a particular property without a block using inline assignment
+  #   <tt>NerdDice.configuration.randomization_technique = :random_new_once</tt>
+  class Configuration
+    attr_reader :randomization_technique
+    attr_accessor :ability_score_array_size, :new_random_interval
+
+    def randomization_technique=(value)
+      unless RANDOMIZATION_TECHNIQUES.include?(value)
+        raise NerdDice::Error, "randomization_technique must be one of #{RANDOMIZATION_TECHNIQUES.join(', ')}"
+      end
+
+      @randomization_technique = value
+    end
+
+    private
+
+      def initialize
+        @ability_score_array_size = 6
+        @randomization_technique = :random_new_once
+        @new_random_interval = 50
+      end
+  end
+end

--- a/spec/nerd_dice/configuration_spec.rb
+++ b/spec/nerd_dice/configuration_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe NerdDice::Configuration do
+  it "has default ability_score_array_size of 6" do
+    config = described_class.new
+    expect(config.ability_score_array_size).to eq(6)
+  end
+
+  it "has default randomization_technique of :random_new_once" do
+    config = described_class.new
+    expect(config.randomization_technique).to eq(:random_new_once)
+  end
+
+  it "has default new_random_interval of 50" do
+    config = described_class.new
+    expect(config.new_random_interval).to eq(50)
+  end
+
+  it "will not let you choose a randomization_technique unless it's on the list" do
+    config = described_class.new
+    expect { config.randomization_technique = :evil_hacker_random }.to raise_error(
+      NerdDice::Error, "randomization_technique must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
+    )
+  end
+
+  it "will let you set randomization_technique to a valid value" do
+    config = described_class.new
+    config.randomization_technique = :random_new_interval
+    expect(config.randomization_technique).to eq(:random_new_interval)
+  end
+end

--- a/spec/nerd_dice_spec.rb
+++ b/spec/nerd_dice_spec.rb
@@ -4,4 +4,12 @@ RSpec.describe NerdDice do
   it "has a version number" do
     expect(NerdDice::VERSION).not_to be nil
   end
+
+  it "can be configured" do
+    described_class.configure do |config|
+      config.ability_score_array_size = 7 # default 6
+    end
+
+    expect(described_class.configuration.ability_score_array_size).to eq(7)
+  end
 end


### PR DESCRIPTION
Add NerdDice::Configuration class that holds configuration for the gem
and is referenced in the NerdDice configuration and configure methods.
Set up the following intitial configuration options:

* ability_score_array_size: number of ability scores to generate
* randomization_technique: choice of options to randomize
* new_random_interval: interval to refresh Random object if
  :random_new_interval is chosen

Completes #8