### PR TITLE
Call :to_i on bonus argument in total_dice

### DIFF
--- a/lib/nerd_dice.rb
+++ b/lib/nerd_dice.rb
@@ -72,7 +72,11 @@ module NerdDice
       number_of_dice.times do
         total += execute_die_roll(number_of_sides)
       end
-      total += opts[:bonus] if opts[:bonus].is_a?(Integer)
+      begin
+        total += opts[:bonus].to_i
+      rescue NoMethodError
+        raise ArgumentError, "Bonus must be a value that responds to :to_i"
+      end
       total
     end
 

--- a/spec/nerd_dice/shared_examples/the_total_dice_method.rb
+++ b/spec/nerd_dice/shared_examples/the_total_dice_method.rb
@@ -28,6 +28,20 @@ RSpec.shared_examples "the total_dice method" do
       end
     end
 
+    it "calculates with a positive bonus correctly with a Float" do
+      sample_size.times do
+        result = described_class.total_dice(6, 3, { bonus: 2.9 })
+        expect(result).to be_between(5, 20)
+      end
+    end
+
+    it "calculates with a positive bonus correctly with a String" do
+      sample_size.times do
+        result = described_class.total_dice(6, 3, { bonus: "2.7" })
+        expect(result).to be_between(5, 20)
+      end
+    end
+
     it "calculates with a zero bonus correctly" do
       sample_size.times do
         result = described_class.total_dice(6, 3, { bonus: 0 })
@@ -38,6 +52,20 @@ RSpec.shared_examples "the total_dice method" do
     it "calculates with a negative penalty correctly" do
       sample_size.times do
         result = described_class.total_dice(6, 3, { bonus: -5 })
+        expect(result).to be_between(-2, 13)
+      end
+    end
+
+    it "calculates with a negative penalty correctly with a Float" do
+      sample_size.times do
+        result = described_class.total_dice(6, 3, { bonus: -5.7 })
+        expect(result).to be_between(-2, 13)
+      end
+    end
+
+    it "calculates with a negative penalty correctly with a String" do
+      sample_size.times do
+        result = described_class.total_dice(6, 3, { bonus: "-5.992" })
         expect(result).to be_between(-2, 13)
       end
     end
@@ -54,6 +82,12 @@ RSpec.shared_examples "the total_dice method" do
         result = described_class.total_dice(6, 1, { bonus: 2 })
         expect(result).to be_between(2, 8)
       end
+    end
+
+    it "raises an error if bonus does not respond to .to_i" do
+      expect { described_class.total_dice(6, 1, { bonus: Kernel }) }.to raise_error(
+        ArgumentError, "Bonus must be a value that responds to :to_i"
+      )
     end
   end
 end


### PR DESCRIPTION
Change the total_dice method to call :to_i instead of is_a? on the bonus
when it is passed into the method from the options hash.

Raise and ArgumentError if the user supplies a value to bonus that does
not respond to the the :to_i method. This allows users to pass in a
Float, String or other duck type to the bonus.

Completes #12 Call .to_i on bonus argument instead of using is_a? in
total_dice method