### PR TITLE
Change NerdDice.total_dice to use keyword args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
 * Add ability to manually refresh or specify seed with `:refresh_seed!` method
 * Added branding .svgs and .pngs to assets/branding
 ### Changed
+* Change `opts = {}` final argument to use keyword args `**opts` in the `NerdDice.total_dice` method. Now the method can be called as follows:
+```ruby
+# old
+NerdDice.total_dice(20, 1, {bonus: 5})
+NerdDice.total_dice(6, 3, {bonus: 1})
+
+# new
+NerdDice.total_dice(20, bonus: 5)
+NerdDice.total_dice(6, 3, bonus: 1)
+```
+* Call `:to_i` on bonus instead of using `:is_a?` and raise ArgumentError in the `NerdDice.total_dice` method if it doesn't respond to `:to_i`
 * Added `securerandom` as an explicit dependency due to Ruby 3.x change to bundled gem
 * `total_dice` no longer calls unqualified `.rand` which improves performance on all generators except for `:securerandom`
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ end
 NerdDice.total_dice(4) # => return random Integer between 1-4
 
 # roll 3d6
-NerdDice.total_dice(6, 3) => return Integer total of three 6-sided dice
+NerdDice.total_dice(6, 3) # => return Integer total of three 6-sided dice
 
 # roll a d20 and add 5 to the value
-NerdDice.total_dice(20, 1, { bonus: 5 })
+NerdDice.total_dice(20, bonus: 5)
 ```
 __NOTE:__ If provided, the bonus must be an ```Integer``` or it will be ignored
 

--- a/lib/nerd_dice.rb
+++ b/lib/nerd_dice.rb
@@ -67,7 +67,7 @@ module NerdDice
     #       all dice after they are totaled, not to each die rolled
     #
     # Return (Integer) => Total of the dice rolled, plus modifier if applicable
-    def total_dice(number_of_sides, number_of_dice = 1, opts = {})
+    def total_dice(number_of_sides, number_of_dice = 1, **opts)
       total = 0
       number_of_dice.times do
         total += execute_die_roll(number_of_sides)

--- a/spec/nerd_dice/shared_examples/the_total_dice_method.rb
+++ b/spec/nerd_dice/shared_examples/the_total_dice_method.rb
@@ -23,69 +23,69 @@ RSpec.shared_examples "the total_dice method" do
   context "with options" do
     it "calculates with a positive bonus correctly" do
       sample_size.times do
-        result = described_class.total_dice(6, 3, { bonus: 2 })
+        result = described_class.total_dice(6, 3, bonus: 2)
         expect(result).to be_between(5, 20)
       end
     end
 
     it "calculates with a positive bonus correctly with a Float" do
       sample_size.times do
-        result = described_class.total_dice(6, 3, { bonus: 2.9 })
+        result = described_class.total_dice(6, 3, bonus: 2.9)
         expect(result).to be_between(5, 20)
       end
     end
 
     it "calculates with a positive bonus correctly with a String" do
       sample_size.times do
-        result = described_class.total_dice(6, 3, { bonus: "2.7" })
+        result = described_class.total_dice(6, 3, bonus: "2.7")
         expect(result).to be_between(5, 20)
       end
     end
 
     it "calculates with a zero bonus correctly" do
       sample_size.times do
-        result = described_class.total_dice(6, 3, { bonus: 0 })
+        result = described_class.total_dice(6, 3, bonus: 0)
         expect(result).to be_between(3, 18)
       end
     end
 
     it "calculates with a negative penalty correctly" do
       sample_size.times do
-        result = described_class.total_dice(6, 3, { bonus: -5 })
+        result = described_class.total_dice(6, 3, bonus: -5)
         expect(result).to be_between(-2, 13)
       end
     end
 
     it "calculates with a negative penalty correctly with a Float" do
       sample_size.times do
-        result = described_class.total_dice(6, 3, { bonus: -5.7 })
+        result = described_class.total_dice(6, 3, bonus: -5.7)
         expect(result).to be_between(-2, 13)
       end
     end
 
     it "calculates with a negative penalty correctly with a String" do
       sample_size.times do
-        result = described_class.total_dice(6, 3, { bonus: "-5.992" })
+        result = described_class.total_dice(6, 3, bonus: "-5.992")
         expect(result).to be_between(-2, 13)
       end
     end
 
     it "ignores non-integer bonus correctly" do
       sample_size.times do
-        result = described_class.total_dice(6, 3, { bonus: "foo" })
+        result = described_class.total_dice(6, 3, bonus: "foo")
         expect(result).to be_between(3, 18)
       end
     end
 
     it "handles one die" do
       sample_size.times do
-        result = described_class.total_dice(6, 1, { bonus: 2 })
+        result = described_class.total_dice(6, bonus: 2)
         expect(result).to be_between(2, 8)
       end
     end
 
     it "raises an error if bonus does not respond to .to_i" do
-      expect { described_class.total_dice(6, 1, { bonus: Kernel }) }.to raise_error(
+      expect { described_class.total_dice(6, bonus: Kernel) }.to raise_error(
         ArgumentError, "Bonus must be a value that responds to :to_i"
       )
     end


### PR DESCRIPTION
Change NerdDice.total_dice method signature to use the double splat
operator to de-reference the opts argument instead of assigning it to an
empty hash. This allows you to omit the optional second argument if you
want to roll one die and add a bonus.

Completes #16 Use keyword argument ** on NerdDice.total_dice options