### PR TITLE
Add randomization_technique option to total_dice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add ability to configure with `NerdDice.configure` block or `NerdDice.configuration`
   - Configure `randomization_technique` as `:random_rand`, `:securerandom`, `:random_object`, or `randomized`
   - Configure `refresh_seed_interval` to allow a periodic refresh of the seed
+* Add `randomization_technique` option to `NerdDice.total_dice` method keyword arguments
 * Add a lower-level `execute_die_roll` method that allows you to roll a single die with a generator specified
 * Add ability to manually refresh or specify seed with `:refresh_seed!` method
 * Added branding .svgs and .pngs to assets/branding

--- a/README.md
+++ b/README.md
@@ -53,8 +53,12 @@ NerdDice.total_dice(6, 3) # => return Integer total of three 6-sided dice
 
 # roll a d20 and add 5 to the value
 NerdDice.total_dice(20, bonus: 5)
+
+# roll a d20 and overide the configured randomization_technique one time
+# without changing the config
+NerdDice.total_dice(20, randomization_technique: :randomized)
 ```
-__NOTE:__ If provided, the bonus must be an ```Integer``` or it will be ignored
+__NOTE:__ If provided, the bonus must respond to `:to_i` or an `ArgumentError` will be raised
 
 ### Manually setting or refreshing the random generator seed
 For randomization techniques other than `:securerandom` you can manually set or refresh the generator's seed by calling the `refresh_seed!` method. This is automatically called at the interval specified in `NerdDice.configuration.refresh_seed_interval` if it is not nil.

--- a/lib/nerd_dice.rb
+++ b/lib/nerd_dice.rb
@@ -70,7 +70,7 @@ module NerdDice
     def total_dice(number_of_sides, number_of_dice = 1, **opts)
       total = 0
       number_of_dice.times do
-        total += execute_die_roll(number_of_sides)
+        total += execute_die_roll(number_of_sides, opts[:randomization_technique])
       end
       begin
         total += opts[:bonus].to_i

--- a/spec/nerd_dice/shared_examples/the_total_dice_method.rb
+++ b/spec/nerd_dice/shared_examples/the_total_dice_method.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+require "support/nerd_dice_helper"
+
+RSpec.configure do |config|
+  config.include NerdDiceHelper
+end
+
 RSpec.shared_examples "the total_dice method" do
   before { NerdDice.configuration.randomization_technique = randomization_technique }
 
@@ -20,7 +26,7 @@ RSpec.shared_examples "the total_dice method" do
     end
   end
 
-  context "with options" do
+  context "with bonus option" do
     it "calculates with a positive bonus correctly" do
       sample_size.times do
         result = described_class.total_dice(6, 3, bonus: 2)
@@ -88,6 +94,31 @@ RSpec.shared_examples "the total_dice method" do
       expect { described_class.total_dice(6, bonus: Kernel) }.to raise_error(
         ArgumentError, "Bonus must be a value that responds to :to_i"
       )
+    end
+  end
+
+  context "with randomization_technique option" do
+    let(:option_gen) { get_different_technique(described_class.configuration.randomization_technique) }
+
+    it "uses the specified option when provided" do
+      sample_size.times do
+        result = described_class.total_dice(20, randomization_technique: option_gen)
+        expect(result).to be_between(1, 20)
+      end
+    end
+
+    it "handles nil" do
+      sample_size.times do
+        result = described_class.total_dice(20, randomization_technique: nil)
+        expect(result).to be_between(1, 20)
+      end
+    end
+
+    it "calclulates the bonus correctly and uses generator with both options" do
+      sample_size.times do
+        result = described_class.total_dice(6, 3, randomization_technique: option_gen, bonus: 3)
+        expect(result).to be_between(6, 21)
+      end
     end
   end
 end

--- a/spec/support/nerd_dice_helper.rb
+++ b/spec/support/nerd_dice_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module NerdDiceHelper
+  def get_different_technique(other_technique)
+    techniques = NerdDice::RANDOMIZATION_TECHNIQUES.shuffle
+    techniques[0] == other_technique ? techniques[1] : techniques[0]
+  end
+end


### PR DESCRIPTION
Add optional keyword argument randomization_technique to
NerdDice.total_dice method that allows you to provide a one-off override
to the configured generator value.

Completes #17 Allow total_dice to take a randomization_technique option