### PR TITLE
Feature/die object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master \(unreleased\)
 ### Added
+* Add `NerdDice::Die` class that represents a single die object and mixes in the `Comparable` module
+* Add `NerdDice::DiceSet` class that represents a collection of `Die` objects and mixes in the `Enumerable` module
+* Add `NerdDice::SetsRandomizationTechnique` mixin module and include in the `DiceSet` and `Die` classes
+* Add `die_background_color` and `die_foreground_color` to `Configuration` class with defaults defined as constants
+* Add `NerdDice.roll_dice` method that behaves in a similar fashion to `total_dice` but returns a `DiceSet` object instead of an `Integer` and has additional optional arguments relating to the non-numeric attributes of the dice
 * Add `coveralls_reborn` to RSpec and GitHub actions
 * Add build badge to README
 * Add Code Climate maintainability integration and badge to README

--- a/README.md
+++ b/README.md
@@ -43,25 +43,125 @@ NerdDice.configure do | config|
     # 1 very slow and heavy pressure on processor and memory but very high entropy
     # 1000 would refresh the object every 1000 times you call rand()
   config.refresh_seed_interval = nil # don't refresh the seed
+  # Background and foreground die colors are string values. By default these correspond to the constants in the class
+    # Defaults: DEFAULT_BACKGROUND_COLOR = "#0000DD" DEFAULT_FOREGROUND_COLOR = "#DDDDDD"
+    # It is recommended but not enforced that these should be valid CSS color property attributes
+  config.die_background_color = "red"
+  config.die_foreground_color = "#000"
 end
 ```
 
 ### Rolling a number of dice and adding a bonus
+You can use two different methods to roll dice. The `total_dice` method returns an `Integer` representing the total of the dice plus any applicable bonuses. The `total_dice` method does not support chaining additional methods like `highest`, `lowest`, `with_advantage`, `with_disadvantage`. The `roll_dice` method returns a `DiceSet` collection object, and allows for chaining  the methods mentioned above and iterating over the individual `Die` objects. `NerdDice.roll_dice.total` and `NerdDice.total_dice` are roughly equivalent.
+
 ```ruby
 # roll a single d4
 NerdDice.total_dice(4) # => return random Integer between 1-4
+NerdDice.roll_dice(4) # => return a DiceSet with one 4-sided Die with a value between 1-4
+NerdDice.roll_dice(4).total # => return random Integer between 1-4
 
 # roll 3d6
 NerdDice.total_dice(6, 3) # => return Integer total of three 6-sided dice
+NerdDice.roll_dice(6, 3) # => return a DiceSet  with three 6-sided Die objects, each with values between 1-6
+NerdDice.roll_dice(6, 3).total # => return Integer total of three 6-sided dice
 
 # roll a d20 and add 5 to the value
-NerdDice.total_dice(20, bonus: 5)
+NerdDice.total_dice(20, bonus: 5) # rolls a d20 and adds the bonus to the total => Integer
+NerdDice.roll_dice(20, bonus: 5) # return a DiceSet with one 20-sided Die with a value between 1-20 and a bonus attribute of 5
+NerdDice.roll_dice(20, bonus: 5).total # rolls a d20 and adds the bonus to the total => Integer
 
+# without changing the config at the module level
 # roll a d20 and overide the configured randomization_technique one time
-# without changing the config
-NerdDice.total_dice(20, randomization_technique: :randomized)
+NerdDice.total_dice(20, randomization_technique: :randomized) # => Integer
+# roll a d20 and overide the configured randomization_technique for the DiceSet object will persist on the DiceSet object for subsequent rerolls
+NerdDice.roll_dice(20, randomization_technique: :randomized) # => DiceSet with randomization_technique: :randomized
 ```
 __NOTE:__ If provided, the bonus must respond to `:to_i` or an `ArgumentError` will be raised
+
+### Taking actions on the dice as objects using the DiceSet object
+The `NerdDice.roll_dice` method or the `NerdDice::DiceSet.new` methods return a collection object with an array of one or more `Die` objects. There are properties on both the `DiceSet` object and the `Die` object. Applicable properties are cascaded from the `DiceSet` to the `Die` objects in the collection by default.
+
+```ruby
+# These are equivalent
+dice_set = NerdDice.roll_dice(6, 3, bonus: 2, randomization_technique: :randomized, damage_type: 'psychic', foreground_color: '#FFF', background_color: '#0FF')
+# => NerdDice::DiceSet
+dice_set = NerdDice::DiceSet.new(6, 3, bonus: 2, randomization_technique: :randomized, damage_type: 'psychic', foreground_color: '#FFF', background_color: '#0FF')
+# => NerdDice::DiceSet
+```
+#### Available options for NerdDice::DiceSet objects
+There are a number of options that can be provided when initializing a `NerdDice::DiceSet` object after specifying the mandatory number of sides and the optional number of dice \(default: 1\). The list below provides the options and indicates whether they are cascaded to the Die objects in the collection.
+* `bonus` \(Duck-type Integer, _default: 0_\): Bonus or penalty to apply to the total after all dice are rolled.  _**Not applied** to Die objects_
+* `randomization_technique` \(Symbol, _default: nil_\): Randomization technique override to use for the `DiceSet`. If `nil` it will use the value in `NerdDice.configuration`. _**Applied** to Die objects by default with ability modify_
+* `damage_type` (\String, _default: nil_\): Optional string indicating the damage type associated with the dice for systems where it is relevant. _**Applied** to Die objects by default with ability modify_
+* `foreground_color` (\String, _default: `NerdDice.configuration.die_foreground_color`_\): Intended foreground color to apply to the dice in the `DiceSet`. Should be a valid CSS color but is not validated or enforced and doesn\'t currently have any real functionality associated with it.   _**Applied** to Die objects by default with ability modify_
+* `background_color` (\String, _default: `NerdDice.configuration.die_background_color`_\): Intended background color to apply to the dice in the `DiceSet`. Should be a valid CSS color but is not validated or enforced and doesn\'t currently have any real functionality associated with it.   _**Applied** to Die objects by default with ability modify_
+
+#### Properties of individual Die objects
+When initialized from a `DiceSet` object most of the properties of the `Die` object are inherited from the `DiceSet` object. In addition, there is an `is_included_in_total` public attribute that can be set to indicate whether the value of that particular die should be included in the total for its parent `DiceSet`. This property always starts out as true when the `Die` is initialized, but can be set to false.
+
+```ruby
+# six sided die
+die = NerdDice::Die.new(6, randomization_technique: :randomized, damage_type: 'psychic', foreground_color: '#FFF', background_color: '#0FF')
+die.is_included_in_total # => true
+die.included_in_total? # => true
+die.is_included_in_total  = false
+die.included_in_total? # => false
+
+# value property
+die.value # =>  Integer between 1 and number_of_sides
+die.roll # => Integer. Rolls/rerolls the Die and sets value to the result of the roll. Returns the new value
+```
+#### Iterating through dices in a DiceSet
+The `DiceSet` class mixes in the `Enumerable` module and the `Die` object mixes in the `Comparable` module. This allows you to iterate over the dice in the collection. The `sort` method on the dice will return the die objects in ascending value from lowest to highest.
+
+```ruby
+dice_set = NerdDice.roll_dice(6, 3) # => NerdDice::DiceSet
+dice_set.dice => Array of Die objects
+dice_set.length # => 3. (dice_set.dice.length)
+dice_set[0] # => NerdDice::Die (first element of dice array)
+# take actions on each die
+dice_set.each do |die|
+  # print the current value
+  puts "Die value before reroll is #{die.value}"
+  # set the foreground_color of the die
+  die.foreground_color = ["gray", "#FF0000#", "#d9d9d9", "green"].shuffle.first
+  # reroll the die
+  die.roll
+  # print the new value
+  puts "Die value after reroll is #{die.value}"
+  # do other things
+end
+```
+#### Methods and method chaining on the DiceSet
+Since the DiceSet is an object, you can call methods that operate on the result returned and allow for things like the 5e advantage/disadvantage mechanic, the ability to re-roll all of the dice in the `DiceSet`, or to mark them all as included in the total.
+
+```ruby
+##############################################
+# highest/with_advantage and lowest/with_disadvantage methods
+#       assuming 4d6 with values of [1, 3, 4, 6]
+##############################################
+dice_set = NerdDice.roll_dice(6, 4)
+# the 6, 4, and 3 will have is_included_in_total true while the 1 has it false
+dice_set.highest(3) # => Returns the existing DiceSet object with the changes made to dice inclusion
+dice_set.with_advantage(3) # => Alias of highest method
+# calling total after highest/with_advantage for this DiceSet
+dice_set.total # => 13
+# same DiceSet using lowest. The 1, 3, and 4 will have is_included_in_total true while the 6 has it false
+dice_set.lowest(3) # => Returns the existing DiceSet object with the changes made to dice inclusion
+dice_set.with_disadvantage(3) # => Alias of lowest method
+# calling total after lowest/with_disadvantage for this DiceSet
+dice_set.total # => 8
+# you can chain these methods (assumes the same seed as the above examples)
+NerdDice.roll_dice(6, 4).with_advantage(3).total # => 13
+NerdDice.roll_dice(6, 4).lowest(3).total # => 8
+
+# reroll_all! method
+dice_set = NerdDice.roll_dice(6, 4)
+dice_set.reroll_all! # rerolls each of the Die objects in the collection and re-includes them in the total
+
+# include_all_dice! method
+dice_set.include_all_dice! # resets is_included_in_total to true for all Die objects
+```
 
 ### Manually setting or refreshing the random generator seed
 For randomization techniques other than `:securerandom` you can manually set or refresh the generator's seed by calling the `refresh_seed!` method. This is automatically called at the interval specified in `NerdDice.configuration.refresh_seed_interval` if it is not nil.

--- a/bin/nerd_dice_benchmark
+++ b/bin/nerd_dice_benchmark
@@ -8,14 +8,22 @@ require "nerd_dice"
 n = 50_000
 
 RATIOS = {
-  nerd_dice_securerandom: 1.7,
-  nerd_dice_random_rand: 11.1,
-  nerd_dice_random_object: 13.0,
-  nerd_dice_randomized: 5.5,
-  nerd_dice_securerandom_3d6: 5.5,
-  nerd_dice_random_rand_3d6: 25.0,
-  nerd_dice_random_object_3d6: 25.5,
-  nerd_dice_randomized_3d6: 15.5
+  total_dice_securerandom: 1.7,
+  total_dice_random_rand: 11.1,
+  total_dice_random_object: 13.0,
+  total_dice_randomized: 5.5,
+  total_dice_securerandom_3d6: 5.5,
+  total_dice_random_rand_3d6: 30.0,
+  total_dice_random_object_3d6: 25.5,
+  total_dice_randomized_3d6: 15.5,
+  roll_dice_securerandom: 4.0,
+  roll_dice_random_rand: 42.0,
+  roll_dice_random_object: 44.0,
+  roll_dice_randomized: 11.5,
+  roll_dice_securerandom_3d6: 13.0,
+  roll_dice_random_rand_3d6: 79.0,
+  roll_dice_random_object_3d6: 86.0,
+  roll_dice_randomized_3d6: 26.5
 }.freeze
 
 def check_against_baseline!(baseline_value, test_value)
@@ -44,22 +52,22 @@ securerandom_baseline = baselines[1].real
 puts "Roll d1000s"
 total_dice_d1000_results = Benchmark.bmbm do |x|
   # NerdDice.total_dice securerandom
-  x.report("nerd_dice_securerandom") do
+  x.report("total_dice_securerandom") do
     NerdDice.configuration.randomization_technique = :securerandom
     n.times { NerdDice.total_dice(1000) }
   end
 
-  x.report("nerd_dice_random_rand") do
+  x.report("total_dice_random_rand") do
     NerdDice.configuration.randomization_technique = :random_rand
     n.times { NerdDice.total_dice(1000) }
   end
 
-  x.report("nerd_dice_random_object") do
+  x.report("total_dice_random_object") do
     NerdDice.configuration.randomization_technique = :random_object
     n.times { NerdDice.total_dice(1000) }
   end
 
-  x.report("nerd_dice_randomized") do
+  x.report("total_dice_randomized") do
     NerdDice.configuration.randomization_technique = :randomized
     n.times { NerdDice.total_dice(1000) }
   end
@@ -74,25 +82,57 @@ check_against_baseline! random_rand_baseline, total_dice_random_object
 total_dice_randomized = total_dice_d1000_results[3]
 check_against_baseline! ((random_rand_baseline * 0.75) + (securerandom_baseline * 0.25)), total_dice_randomized
 
+roll_dice_d1000_results = Benchmark.bmbm do |x|
+  # NerdDice.roll_dice securerandom
+  x.report("roll_dice_securerandom") do
+    NerdDice.configuration.randomization_technique = :securerandom
+    n.times { NerdDice.roll_dice(1000) }
+  end
+
+  x.report("roll_dice_random_rand") do
+    NerdDice.configuration.randomization_technique = :random_rand
+    n.times { NerdDice.roll_dice(1000) }
+  end
+
+  x.report("roll_dice_random_object") do
+    NerdDice.configuration.randomization_technique = :random_object
+    n.times { NerdDice.roll_dice(1000) }
+  end
+
+  x.report("roll_dice_randomized") do
+    NerdDice.configuration.randomization_technique = :randomized
+    n.times { NerdDice.roll_dice(1000) }
+  end
+end
+
+roll_dice_securerandom = roll_dice_d1000_results[0]
+check_against_baseline! securerandom_baseline, roll_dice_securerandom
+roll_dice_random_rand = roll_dice_d1000_results[1]
+check_against_baseline! random_rand_baseline, roll_dice_random_rand
+roll_dice_random_object = roll_dice_d1000_results[2]
+check_against_baseline! random_rand_baseline, roll_dice_random_object
+roll_dice_randomized = roll_dice_d1000_results[3]
+check_against_baseline! ((random_rand_baseline * 0.75) + (securerandom_baseline * 0.25)), roll_dice_randomized
+
 puts "Roll 3d6"
 total_dice_3d6_results = Benchmark.bmbm do |x|
   # NerdDice.total_dice securerandom
-  x.report("nerd_dice_securerandom_3d6") do
+  x.report("total_dice_securerandom_3d6") do
     NerdDice.configuration.randomization_technique = :securerandom
     n.times { NerdDice.total_dice(6, 3) }
   end
 
-  x.report("nerd_dice_random_rand_3d6") do
+  x.report("total_dice_random_rand_3d6") do
     NerdDice.configuration.randomization_technique = :random_rand
     n.times { NerdDice.total_dice(6, 3) }
   end
 
-  x.report("nerd_dice_random_object_3d6") do
+  x.report("total_dice_random_object_3d6") do
     NerdDice.configuration.randomization_technique = :random_object
     n.times { NerdDice.total_dice(6, 3) }
   end
 
-  x.report("nerd_dice_randomized_3d6") do
+  x.report("total_dice_randomized_3d6") do
     NerdDice.configuration.randomization_technique = :randomized
     n.times { NerdDice.total_dice(6, 3) }
   end
@@ -106,3 +146,35 @@ total_dice_3d6_random_object = total_dice_3d6_results[2]
 check_against_baseline! random_rand_baseline, total_dice_3d6_random_object
 total_dice_3d6_randomized = total_dice_3d6_results[3]
 check_against_baseline! ((random_rand_baseline * 0.75) + (securerandom_baseline * 0.25)), total_dice_3d6_randomized
+
+roll_dice_3d6_results = Benchmark.bmbm do |x|
+  # NerdDice.roll_dice securerandom
+  x.report("roll_dice_securerandom_3d6") do
+    NerdDice.configuration.randomization_technique = :securerandom
+    n.times { NerdDice.roll_dice(6, 3) }
+  end
+
+  x.report("roll_dice_random_rand_3d6") do
+    NerdDice.configuration.randomization_technique = :random_rand
+    n.times { NerdDice.roll_dice(6, 3) }
+  end
+
+  x.report("roll_dice_random_object_3d6") do
+    NerdDice.configuration.randomization_technique = :random_object
+    n.times { NerdDice.roll_dice(6, 3) }
+  end
+
+  x.report("roll_dice_randomized_3d6") do
+    NerdDice.configuration.randomization_technique = :randomized
+    n.times { NerdDice.roll_dice(6, 3) }
+  end
+end
+
+roll_dice_3d6_securerandom = roll_dice_3d6_results[0]
+check_against_baseline! securerandom_baseline, roll_dice_3d6_securerandom
+roll_dice_3d6_random_rand = roll_dice_3d6_results[1]
+check_against_baseline! random_rand_baseline, roll_dice_3d6_random_rand
+roll_dice_3d6_random_object = roll_dice_3d6_results[2]
+check_against_baseline! random_rand_baseline, roll_dice_3d6_random_object
+roll_dice_3d6_randomized = roll_dice_3d6_results[3]
+check_against_baseline! ((random_rand_baseline * 0.75) + (securerandom_baseline * 0.25)), roll_dice_3d6_randomized

--- a/bin/nerd_dice_benchmark
+++ b/bin/nerd_dice_benchmark
@@ -15,7 +15,7 @@ RATIOS = {
   nerd_dice_securerandom_3d6: 5.5,
   nerd_dice_random_rand_3d6: 25.0,
   nerd_dice_random_object_3d6: 25.5,
-  nerd_dice_randomized_3d6: 14.5
+  nerd_dice_randomized_3d6: 15.5
 }.freeze
 
 def check_against_baseline!(baseline_value, test_value)

--- a/lib/nerd_dice.rb
+++ b/lib/nerd_dice.rb
@@ -86,6 +86,31 @@ module NerdDice
     end
 
     ############################
+    # roll_dice class method
+    ############################
+    # Arguments:
+    #   number_of_sides (Integer) =>  the number of sides of the dice to roll
+    #   number_of_dice (Integer, DEFAULT: 1) => the quantity to roll of the type
+    #     of die specified in the number_of_sides argument.
+    #   options (Hash, DEFAULT: {}) any additional options you wish to include
+    #     :bonus (Integer) => The total bonus (positive integer) or penalty
+    #       (negative integer) to modify the total by. Is added to the total of
+    #       all dice after they are totaled, not to each die rolled
+    #     :randomization_technique (Symbol) => must be one of the symbols in
+    #       RANDOMIZATION_TECHNIQUES or nil
+    #     :foreground_color (String) => should resolve to a valid CSS color (format flexible)
+    #     :background_color (String) => should resolve to a valid CSS color (format flexible)
+    #     :damage_type: (String) => damage type for the dice set, if applicable
+    #
+    # Return (NerdDice::DiceSet) => Collection object with one or more Die objects
+    #
+    # You can call roll_dice().total to get similar functionality to total_dice
+    # or you can chain methods together roll_dice(6, 4, bonus: 3).with_advantage(3).total
+    def roll_dice(number_of_sides, number_of_dice = 1, **opts)
+      DiceSet.new(number_of_sides, number_of_dice, **opts)
+    end
+
+    ############################
     # execute_die_roll class method
     ############################
     # Arguments:

--- a/lib/nerd_dice.rb
+++ b/lib/nerd_dice.rb
@@ -3,6 +3,7 @@
 require "nerd_dice/version"
 require "nerd_dice/configuration"
 require "nerd_dice/die"
+require "nerd_dice/dice_set"
 require "securerandom"
 # Nerd dice allows you to roll polyhedral dice and add bonuses as you would in
 # a tabletop roleplaying game. You can choose to roll multiple dice and keep a
@@ -66,6 +67,8 @@ module NerdDice
     #     :bonus (Integer) => The total bonus (positive integer) or penalty
     #       (negative integer) to modify the total by. Is added to the total of
     #       all dice after they are totaled, not to each die rolled
+    #     :randomization_technique (Symbol) => must be one of the symbols in
+    #       RANDOMIZATION_TECHNIQUES or nil
     #
     # Return (Integer) => Total of the dice rolled, plus modifier if applicable
     def total_dice(number_of_sides, number_of_dice = 1, **opts)

--- a/lib/nerd_dice.rb
+++ b/lib/nerd_dice.rb
@@ -2,6 +2,7 @@
 
 require "nerd_dice/version"
 require "nerd_dice/configuration"
+require "nerd_dice/die"
 require "securerandom"
 # Nerd dice allows you to roll polyhedral dice and add bonuses as you would in
 # a tabletop roleplaying game. You can choose to roll multiple dice and keep a

--- a/lib/nerd_dice.rb
+++ b/lib/nerd_dice.rb
@@ -2,6 +2,7 @@
 
 require "nerd_dice/version"
 require "nerd_dice/configuration"
+require "nerd_dice/sets_randomization_technique"
 require "nerd_dice/die"
 require "nerd_dice/dice_set"
 require "securerandom"

--- a/lib/nerd_dice/configuration.rb
+++ b/lib/nerd_dice/configuration.rb
@@ -19,7 +19,10 @@ module NerdDice
   #   <tt>NerdDice.configuration.randomization_technique = :random_new_once</tt>
   class Configuration
     attr_reader :randomization_technique, :refresh_seed_interval
-    attr_accessor :ability_score_array_size
+    attr_accessor :ability_score_array_size, :die_background_color, :die_foreground_color
+
+    DEFAULT_BACKGROUND_COLOR = "#0000DD"
+    DEFAULT_FOREGROUND_COLOR = "#DDDDDD"
 
     def randomization_technique=(value)
       unless RANDOMIZATION_TECHNIQUES.include?(value)
@@ -42,6 +45,8 @@ module NerdDice
       def initialize
         @ability_score_array_size = 6
         @randomization_technique = :random_object
+        @die_background_color = DEFAULT_BACKGROUND_COLOR
+        @die_foreground_color = DEFAULT_FOREGROUND_COLOR
       end
   end
 end

--- a/lib/nerd_dice/dice_set.rb
+++ b/lib/nerd_dice/dice_set.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module NerdDice
+  # The NerdDice::DiceSet class allows you to instantiate and roll a set of dice by specifying
+  # the number of sides, the number of dice (with a default of 1) and other options. As part of
+  # initialization the DiceSet will initialize and roll the Die objects specified by the
+  # DiceSet.new method. The parameters align with the NerdDice.total_dice method and
+  # NerdDice::DiceSet.new(6, 3, bonus: 5).total would be equivalent to
+  # NerdDice.total_dice(6, 3, bonus: 5)
+  #
+  # Usage:
+  #   Instantiate a d20:
+  #   <tt>dice = NerdDice::DiceSet.new(20)
+  #       dice.total # between 1 and 20
+  #   </tt>
+  #
+  #   Instantiate 3d6 + 5:
+  #   <tt>dice = NerdDice::DiceSet.new(6, 3, bonus: 5)
+  #       dice.total # between 8 and 23
+  #   </tt>
+  #
+  #   You can also specify options that will cascade to the member dice when instantiating
+  #   <tt>NerdDice::DiceSet.new(6, 3, randomization_technique: :randomized,
+  #                        foreground_color: "#FF0000",
+  #                        background_color: "#FFFFFF"
+  #                        damage_type: "necrotic"))
+  #   </tt>
+  class DiceSet
+    attr_reader :number_of_sides, :number_of_dice, :randomization_technique, :dice, :bonus
+    attr_accessor :background_color, :foreground_color, :damage_type
+
+    def randomization_technique=(new_value)
+      unless RANDOMIZATION_TECHNIQUES.include?(new_value) || new_value.nil?
+        raise NerdDice::Error, "randomization_technique must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
+      end
+
+      @randomization_technique = new_value
+    end
+
+    def total
+      @dice.sum(&:value) + @bonus
+    end
+
+    private
+
+      def initialize(number_of_sides, number_of_dice = 1, **opts)
+        @number_of_sides = number_of_sides
+        @number_of_dice = number_of_dice
+        parse_options(opts)
+        @dice = []
+        @number_of_dice.times { @dice << Die.new(@number_of_sides, **opts) }
+      end
+
+      def parse_options(opts)
+        self.randomization_technique = opts[:randomization_technique]
+        @background_color = opts[:background_color] || NerdDice.configuration.die_background_color
+        @foreground_color = opts[:foreground_color] || NerdDice.configuration.die_foreground_color
+        @damage_type = opts[:damage_type]
+        begin
+          @bonus = opts[:bonus].to_i
+        rescue NoMethodError
+          raise ArgumentError, "Bonus must be a value that responds to :to_i"
+        end
+      end
+  end
+end

--- a/lib/nerd_dice/dice_set.rb
+++ b/lib/nerd_dice/dice_set.rb
@@ -47,7 +47,12 @@ module NerdDice
       @dice.map(&:roll)
     end
 
+    def include_all_dice!
+      @dice.map { |die| die.is_included_in_total = true }
+    end
+
     def highest(number_to_take = nil)
+      include_all_dice!
       number_to_take = check_low_high_argument!(number_to_take)
       get_default_to_take if number_to_take.nil?
       @dice.sort.reverse.each_with_index do |die, index|
@@ -59,6 +64,7 @@ module NerdDice
     alias with_advantage highest
 
     def lowest(number_to_take = nil)
+      include_all_dice!
       number_to_take = check_low_high_argument!(number_to_take)
       get_default_to_take if number_to_take.nil?
       @dice.sort.each_with_index do |die, index|

--- a/lib/nerd_dice/dice_set.rb
+++ b/lib/nerd_dice/dice_set.rb
@@ -47,6 +47,28 @@ module NerdDice
       @dice.map(&:roll)
     end
 
+    def highest(number_to_take = nil)
+      number_to_take = check_low_high_argument!(number_to_take)
+      get_default_to_take if number_to_take.nil?
+      @dice.sort.reverse.each_with_index do |die, index|
+        die.is_included_in_total = false if index >= number_to_take
+      end
+      self
+    end
+
+    alias with_advantage highest
+
+    def lowest(number_to_take = nil)
+      number_to_take = check_low_high_argument!(number_to_take)
+      get_default_to_take if number_to_take.nil?
+      @dice.sort.each_with_index do |die, index|
+        die.is_included_in_total = false if index >= number_to_take
+      end
+      self
+    end
+
+    alias with_disadvantage lowest
+
     def randomization_technique=(new_value)
       unless RANDOMIZATION_TECHNIQUES.include?(new_value) || new_value.nil?
         raise NerdDice::Error, "randomization_technique must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
@@ -56,7 +78,7 @@ module NerdDice
     end
 
     def total
-      @dice.sum(&:value) + @bonus
+      @dice.select(&:included_in_total?).sum(&:value) + @bonus
     end
 
     private
@@ -79,6 +101,13 @@ module NerdDice
         rescue NoMethodError
           raise ArgumentError, "Bonus must be a value that responds to :to_i"
         end
+      end
+
+      def check_low_high_argument!(number_to_take)
+        number_to_take ||= number_of_dice == 1 ? 1 : number_of_dice - 1
+        raise ArgumentError, "Argument cannot exceed number of dice" if number_to_take > number_of_dice
+
+        number_to_take
       end
   end
 end

--- a/lib/nerd_dice/dice_set.rb
+++ b/lib/nerd_dice/dice_set.rb
@@ -52,8 +52,11 @@ module NerdDice
       @dice.reverse!
     end
 
-    def reroll_all
-      @dice.map(&:roll)
+    def reroll_all!
+      @dice.map do |die|
+        die.roll
+        die.is_included_in_total = true
+      end
     end
 
     def include_all_dice!

--- a/lib/nerd_dice/dice_set.rb
+++ b/lib/nerd_dice/dice_set.rb
@@ -83,6 +83,12 @@ module NerdDice
       @randomization_technique = new_value
     end
 
+    def bonus=(new_value)
+      @bonus = new_value.to_i
+    rescue NoMethodError
+      raise ArgumentError, "Bonus must be a value that responds to :to_i"
+    end
+
     def total
       @dice.select(&:included_in_total?).sum(&:value) + @bonus
     end
@@ -102,11 +108,7 @@ module NerdDice
         @background_color = opts[:background_color] || NerdDice.configuration.die_background_color
         @foreground_color = opts[:foreground_color] || NerdDice.configuration.die_foreground_color
         @damage_type = opts[:damage_type]
-        begin
-          @bonus = opts[:bonus].to_i
-        rescue NoMethodError
-          raise ArgumentError, "Bonus must be a value that responds to :to_i"
-        end
+        self.bonus = opts[:bonus]
       end
 
       def check_low_high_argument!(number_to_take)

--- a/lib/nerd_dice/dice_set.rb
+++ b/lib/nerd_dice/dice_set.rb
@@ -27,8 +27,9 @@ module NerdDice
   #   </tt>
   class DiceSet
     include Enumerable
+    include SetsRandomizationTechnique
 
-    attr_reader :number_of_sides, :number_of_dice, :randomization_technique, :dice, :bonus
+    attr_reader :number_of_sides, :number_of_dice, :dice, :bonus
     attr_accessor :background_color, :foreground_color, :damage_type
 
     def each(&block)
@@ -74,14 +75,6 @@ module NerdDice
     end
 
     alias with_disadvantage lowest
-
-    def randomization_technique=(new_value)
-      unless RANDOMIZATION_TECHNIQUES.include?(new_value) || new_value.nil?
-        raise NerdDice::Error, "randomization_technique must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
-      end
-
-      @randomization_technique = new_value
-    end
 
     def bonus=(new_value)
       @bonus = new_value.to_i

--- a/lib/nerd_dice/dice_set.rb
+++ b/lib/nerd_dice/dice_set.rb
@@ -44,6 +44,14 @@ module NerdDice
       @dice.length
     end
 
+    def sort!
+      @dice.sort!
+    end
+
+    def reverse!
+      @dice.reverse!
+    end
+
     def reroll_all
       @dice.map(&:roll)
     end

--- a/lib/nerd_dice/dice_set.rb
+++ b/lib/nerd_dice/dice_set.rb
@@ -26,8 +26,26 @@ module NerdDice
   #                        damage_type: "necrotic"))
   #   </tt>
   class DiceSet
+    include Enumerable
+
     attr_reader :number_of_sides, :number_of_dice, :randomization_technique, :dice, :bonus
     attr_accessor :background_color, :foreground_color, :damage_type
+
+    def each(&block)
+      @dice.each(&block)
+    end
+
+    def [](index)
+      @dice[index]
+    end
+
+    def length
+      @dice.length
+    end
+
+    def reroll_all
+      @dice.map(&:roll)
+    end
 
     def randomization_technique=(new_value)
       unless RANDOMIZATION_TECHNIQUES.include?(new_value) || new_value.nil?

--- a/lib/nerd_dice/die.rb
+++ b/lib/nerd_dice/die.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module NerdDice
+  # The NerdDice::Die class allows you to instantiate and roll a die by specifying
+  # the number of sides with other options. As part of initialization the die will
+  # be rolled and have a value
+  #
+  # Usage:
+  #   Instantiate a d20:
+  #   <tt>die = NerdDice::Die.new(20)
+  #       die.value # between 1 and 20
+  #   </tt>
+  #
+  #   You can also specify options when instantiating
+  #   <tt>NerdDice::Die.new(12, generator_override: :randomized,
+  #                        foreground_color: "#FF0000",
+  #                        background_color: "#FFFFFF"))
+  #   </tt>
+  class Die
+    attr_reader :number_of_sides, :generator_override, :value
+    attr_accessor :background_color, :foreground_color
+
+    DEFAULT_BACKGROUND = "#0000FF"
+    DEFAULT_FOREGROUND = "#FFFFFF"
+
+    def generator_override=(new_value)
+      puts "new_value is #{new_value}"
+      check_override!(new_value)
+      @generator_override = new_value
+    end
+
+    # rolls the die, setting the value to the new roll and returning that value
+    def roll
+      @value = NerdDice.execute_die_roll(@number_of_sides, @generator_override)
+    end
+
+    private
+
+      def initialize(number_of_sides, **opts)
+        @number_of_sides = number_of_sides
+        puts "Options #{opts}"
+        check_override!(opts[:generator_override])
+        @generator_override = opts[:generator_override]
+        @background_color = opts[:background_color] || DEFAULT_BACKGROUND
+        @foreground_color = opts[:foreground_color] || DEFAULT_FOREGROUND
+        roll
+      end
+
+      def check_override!(new_value)
+        unless RANDOMIZATION_TECHNIQUES.include?(new_value) || new_value.nil?
+          raise NerdDice::Error, "generator_override must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
+        end
+
+        true
+      end
+  end
+end

--- a/lib/nerd_dice/die.rb
+++ b/lib/nerd_dice/die.rb
@@ -20,10 +20,7 @@ module NerdDice
     include Comparable
 
     attr_reader :number_of_sides, :generator_override, :value
-    attr_accessor :background_color, :foreground_color
-
-    DEFAULT_BACKGROUND = "#0000FF"
-    DEFAULT_FOREGROUND = "#FFFFFF"
+    attr_accessor :background_color, :foreground_color, :damage_type
 
     def <=>(other)
       value <=> other.value
@@ -47,8 +44,9 @@ module NerdDice
       def initialize(number_of_sides, **opts)
         @number_of_sides = number_of_sides
         self.generator_override = opts[:generator_override]
-        @background_color = opts[:background_color] || DEFAULT_BACKGROUND
-        @foreground_color = opts[:foreground_color] || DEFAULT_FOREGROUND
+        @background_color = opts[:background_color] || NerdDice.configuration.die_background_color
+        @foreground_color = opts[:foreground_color] || NerdDice.configuration.die_foreground_color
+        @damage_type = opts[:damage_type]
         roll
       end
   end

--- a/lib/nerd_dice/die.rb
+++ b/lib/nerd_dice/die.rb
@@ -12,38 +12,39 @@ module NerdDice
   #   </tt>
   #
   #   You can also specify options when instantiating
-  #   <tt>NerdDice::Die.new(12, generator_override: :randomized,
+  #   <tt>NerdDice::Die.new(12, randomization_technique: :randomized,
   #                        foreground_color: "#FF0000",
-  #                        background_color: "#FFFFFF"))
+  #                        background_color: "#FFFFFF",
+  #                        damage_type: "necrotic"))
   #   </tt>
   class Die
     include Comparable
 
-    attr_reader :number_of_sides, :generator_override, :value
+    attr_reader :number_of_sides, :randomization_technique, :value
     attr_accessor :background_color, :foreground_color, :damage_type
 
     def <=>(other)
       value <=> other.value
     end
 
-    def generator_override=(new_value)
+    def randomization_technique=(new_value)
       unless RANDOMIZATION_TECHNIQUES.include?(new_value) || new_value.nil?
-        raise NerdDice::Error, "generator_override must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
+        raise NerdDice::Error, "randomization_technique must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
       end
 
-      @generator_override = new_value
+      @randomization_technique = new_value
     end
 
     # rolls the die, setting the value to the new roll and returning that value
     def roll
-      @value = NerdDice.execute_die_roll(@number_of_sides, @generator_override)
+      @value = NerdDice.execute_die_roll(@number_of_sides, @randomization_technique)
     end
 
     private
 
       def initialize(number_of_sides, **opts)
         @number_of_sides = number_of_sides
-        self.generator_override = opts[:generator_override]
+        self.randomization_technique = opts[:randomization_technique]
         @background_color = opts[:background_color] || NerdDice.configuration.die_background_color
         @foreground_color = opts[:foreground_color] || NerdDice.configuration.die_foreground_color
         @damage_type = opts[:damage_type]

--- a/lib/nerd_dice/die.rb
+++ b/lib/nerd_dice/die.rb
@@ -17,15 +17,23 @@ module NerdDice
   #                        background_color: "#FFFFFF"))
   #   </tt>
   class Die
+    include Comparable
+
     attr_reader :number_of_sides, :generator_override, :value
     attr_accessor :background_color, :foreground_color
 
     DEFAULT_BACKGROUND = "#0000FF"
     DEFAULT_FOREGROUND = "#FFFFFF"
 
+    def <=>(other)
+      value <=> other.value
+    end
+
     def generator_override=(new_value)
-      puts "new_value is #{new_value}"
-      check_override!(new_value)
+      unless RANDOMIZATION_TECHNIQUES.include?(new_value) || new_value.nil?
+        raise NerdDice::Error, "generator_override must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
+      end
+
       @generator_override = new_value
     end
 
@@ -38,20 +46,10 @@ module NerdDice
 
       def initialize(number_of_sides, **opts)
         @number_of_sides = number_of_sides
-        puts "Options #{opts}"
-        check_override!(opts[:generator_override])
-        @generator_override = opts[:generator_override]
+        self.generator_override = opts[:generator_override]
         @background_color = opts[:background_color] || DEFAULT_BACKGROUND
         @foreground_color = opts[:foreground_color] || DEFAULT_FOREGROUND
         roll
-      end
-
-      def check_override!(new_value)
-        unless RANDOMIZATION_TECHNIQUES.include?(new_value) || new_value.nil?
-          raise NerdDice::Error, "generator_override must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
-        end
-
-        true
       end
   end
 end

--- a/lib/nerd_dice/die.rb
+++ b/lib/nerd_dice/die.rb
@@ -19,20 +19,13 @@ module NerdDice
   #   </tt>
   class Die
     include Comparable
+    include SetsRandomizationTechnique
 
-    attr_reader :number_of_sides, :randomization_technique, :value
+    attr_reader :number_of_sides, :value
     attr_accessor :background_color, :foreground_color, :damage_type, :is_included_in_total
 
     def <=>(other)
       value <=> other.value
-    end
-
-    def randomization_technique=(new_value)
-      unless RANDOMIZATION_TECHNIQUES.include?(new_value) || new_value.nil?
-        raise NerdDice::Error, "randomization_technique must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
-      end
-
-      @randomization_technique = new_value
     end
 
     # rolls the die, setting the value to the new roll and returning that value

--- a/lib/nerd_dice/die.rb
+++ b/lib/nerd_dice/die.rb
@@ -21,7 +21,7 @@ module NerdDice
     include Comparable
 
     attr_reader :number_of_sides, :randomization_technique, :value
-    attr_accessor :background_color, :foreground_color, :damage_type
+    attr_accessor :background_color, :foreground_color, :damage_type, :is_included_in_total
 
     def <=>(other)
       value <=> other.value
@@ -40,6 +40,8 @@ module NerdDice
       @value = NerdDice.execute_die_roll(@number_of_sides, @randomization_technique)
     end
 
+    alias included_in_total? is_included_in_total
+
     private
 
       def initialize(number_of_sides, **opts)
@@ -48,6 +50,7 @@ module NerdDice
         @background_color = opts[:background_color] || NerdDice.configuration.die_background_color
         @foreground_color = opts[:foreground_color] || NerdDice.configuration.die_foreground_color
         @damage_type = opts[:damage_type]
+        @is_included_in_total = true
         roll
       end
   end

--- a/lib/nerd_dice/die.rb
+++ b/lib/nerd_dice/die.rb
@@ -24,6 +24,7 @@ module NerdDice
     attr_reader :number_of_sides, :value
     attr_accessor :background_color, :foreground_color, :damage_type, :is_included_in_total
 
+    # comparison operator override using value: required to implement Comparable
     def <=>(other)
       value <=> other.value
     end

--- a/lib/nerd_dice/sets_randomization_technique.rb
+++ b/lib/nerd_dice/sets_randomization_technique.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module NerdDice
+  # The NerdDice::SetsRandomizationTechnique is a module mixin that can be included
+  # in classes. It provides an attribute reader and writer for randomization_technique
+  # and checks against the NerdDice::RANDOMIZATION_TECHNIQUES constant to make sure the
+  # input provided is valid
+  module SetsRandomizationTechnique
+    attr_reader :randomization_technique
+
+    def randomization_technique=(new_value)
+      unless RANDOMIZATION_TECHNIQUES.include?(new_value) || new_value.nil?
+        raise NerdDice::Error, "randomization_technique must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
+      end
+
+      @randomization_technique = new_value
+    end
+  end
+end

--- a/spec/nerd_dice/configuration_spec.rb
+++ b/spec/nerd_dice/configuration_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe NerdDice::Configuration do
     expect(config.refresh_seed_interval).to be_nil
   end
 
+  it "has default die_background_color of #0000DD" do
+    expect(config.die_background_color).to eq("#0000DD")
+  end
+
+  it "has default die_background_color of #DDDDDD" do
+    expect(config.die_foreground_color).to eq("#DDDDDD")
+  end
+
   it "allows you to set refresh_seed_interval to 5000" do
     config.refresh_seed_interval = 5000
     expect(config.refresh_seed_interval).to eq(5000)
@@ -41,5 +49,15 @@ RSpec.describe NerdDice::Configuration do
   it "will let you set randomization_technique to a valid value" do
     config.randomization_technique = :securerandom
     expect(config.randomization_technique).to eq(:securerandom)
+  end
+
+  it "will let you set the die_background_color" do
+    config.die_background_color = "#DD0000"
+    expect(config.die_background_color).to eq("#DD0000")
+  end
+
+  it "will let you set the die_foreground_color" do
+    config.die_foreground_color = "#00DD00"
+    expect(config.die_foreground_color).to eq("#00DD00")
   end
 end

--- a/spec/nerd_dice/dice_set_spec.rb
+++ b/spec/nerd_dice/dice_set_spec.rb
@@ -253,6 +253,35 @@ RSpec.describe NerdDice::DiceSet do
     end
   end
 
+  describe "collection methods" do
+    before { NerdDice.refresh_seed!(randomization_technique: :random_rand, random_rand_seed: 1337) }
+
+    let(:dice) { described_class.new 6, 3, randomization_technique: :random_rand }
+
+    describe "sort! method" do
+      it "returns the dice sorted in order" do
+        expect(dice.sort!.map(&:value)).to eq([1, 5, 6])
+      end
+
+      it "changes the order of the dice collection on the dice set" do
+        dice.sort!
+        expect(dice[0].value).to eq(1)
+      end
+    end
+
+    describe "reverse! method" do
+      before { dice.sort! }
+      it "returns the dice in reverse order" do
+        expect(dice.reverse!.map(&:value)).to eq([6, 5, 1])
+      end
+
+      it "changes the order of the dice collection on the dice set" do
+        dice.reverse!
+        expect(dice[0].value).to eq(6)
+      end
+    end
+  end
+
   describe "highest and with_advantage methods" do
     before { NerdDice.refresh_seed!(randomization_technique: :random_rand, random_rand_seed: 24_601) }
 

--- a/spec/nerd_dice/dice_set_spec.rb
+++ b/spec/nerd_dice/dice_set_spec.rb
@@ -231,25 +231,33 @@ RSpec.describe NerdDice::DiceSet do
     end
   end
 
-  describe "the reroll_all method" do
+  describe "the reroll_all! method" do
     before { NerdDice.refresh_seed!(randomization_technique: :random_rand, random_rand_seed: 1337) }
 
     let(:dice) { described_class.new 6, 3, randomization_technique: :random_rand }
 
     it "changes the total" do
-      expect { dice.reroll_all }.to change(dice, :total)
+      expect { dice.reroll_all! }.to change(dice, :total)
     end
 
     it "changes the first die" do
-      expect { dice.reroll_all }.to change(dice[0], :value)
+      expect { dice.reroll_all! }.to change(dice[0], :value)
     end
 
     it "changes the second die" do
-      expect { dice.reroll_all }.to change(dice[1], :value)
+      expect { dice.reroll_all! }.to change(dice[1], :value)
     end
 
     it "changes the third die" do
-      expect { dice.reroll_all }.to change(dice[2], :value)
+      expect { dice.reroll_all! }.to change(dice[2], :value)
+    end
+
+    it "resets is_included_in_total to true for all dice" do
+      dice.each { |die| die.is_included_in_total = false }
+      dice.reroll_all!
+      dice.each do |die|
+        expect(die.is_included_in_total).to eq(true)
+      end
     end
   end
 

--- a/spec/nerd_dice/dice_set_spec.rb
+++ b/spec/nerd_dice/dice_set_spec.rb
@@ -337,4 +337,19 @@ RSpec.describe NerdDice::DiceSet do
       end
     end
   end
+
+  describe "custom attribute writers" do
+    describe "bonus= method" do
+      it "lets you set the bonus" do
+        dice_set.bonus = 14
+        expect(dice_set.bonus).to eq(14)
+      end
+
+      it "errors out if you provide invalid input" do
+        expect { dice_set.bonus = :flump }.to raise_error(
+          ArgumentError, "Bonus must be a value that responds to :to_i"
+        )
+      end
+    end
+  end
 end

--- a/spec/nerd_dice/dice_set_spec.rb
+++ b/spec/nerd_dice/dice_set_spec.rb
@@ -327,4 +327,14 @@ RSpec.describe NerdDice::DiceSet do
       )
     end
   end
+
+  describe "include_all_dice! method" do
+    it "changes is_included_in_total to true for all dice" do
+      dice_set.each { |die| die.is_included_in_total = false }
+      dice_set.include_all_dice!
+      dice_set.each do |die|
+        expect(die.included_in_total?).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/nerd_dice/dice_set_spec.rb
+++ b/spec/nerd_dice/dice_set_spec.rb
@@ -279,6 +279,7 @@ RSpec.describe NerdDice::DiceSet do
 
     describe "reverse! method" do
       before { dice.sort! }
+
       it "returns the dice in reverse order" do
         expect(dice.reverse!.map(&:value)).to eq([6, 5, 1])
       end

--- a/spec/nerd_dice/dice_set_spec.rb
+++ b/spec/nerd_dice/dice_set_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+RSpec.describe NerdDice::DiceSet do
+  subject(:dice_set) { described_class.new(6, 3) }
+
+  let(:dice_options) do
+    {
+      randomization_technique: :randomized,
+      foreground_color: "#FF0000",
+      background_color: "#FFFFFF",
+      damage_type: "fire",
+      bonus: 5
+    }
+  end
+
+  context "with one die and no options" do
+    let(:one_die) { described_class.new(20) }
+
+    it "sets the number of sides from the first argument" do
+      expect(one_die.number_of_sides).to eq(20)
+    end
+
+    it "has the default number of dice equal to 1" do
+      expect(one_die.number_of_dice).to eq(1)
+    end
+
+    it "has expected randomization technique of nil" do
+      expect(one_die.randomization_technique).to be_nil
+    end
+
+    it "has expected default foreground_color of #DDDDDD" do
+      expect(one_die.foreground_color).to eq("#DDDDDD")
+    end
+
+    it "has expected default background_color of #0000DD" do
+      expect(one_die.background_color).to eq("#0000DD")
+    end
+
+    it "has a damage_type of nil" do
+      expect(one_die.damage_type).to be_nil
+    end
+
+    it "has a total between 1 and number of sides" do
+      expect(one_die.total).to be_between(1, 20)
+    end
+
+    it "has a dice property with a length of 1" do
+      expect(one_die.dice.length).to eq(1)
+    end
+
+    it "has an element in dice that is a Die object" do
+      expect(one_die.dice[0]).to be_a(NerdDice::Die)
+    end
+  end
+
+  context "with three dice and no options" do
+    it "sets the number of sides from the first argument" do
+      expect(dice_set.number_of_sides).to eq(6)
+    end
+
+    it "sets the number of dice from the second argument" do
+      expect(dice_set.number_of_dice).to eq(3)
+    end
+
+    it "has expected randomization technique of nil" do
+      expect(dice_set.randomization_technique).to be_nil
+    end
+
+    it "has expected default foreground_color of #DDDDDD" do
+      expect(dice_set.foreground_color).to eq("#DDDDDD")
+    end
+
+    it "has expected default background_color of #0000DD" do
+      expect(dice_set.background_color).to eq("#0000DD")
+    end
+
+    it "has a damage_type of nil" do
+      expect(dice_set.damage_type).to be_nil
+    end
+
+    it "has a total between number of dice and dice times sides" do
+      expect(dice_set.total).to be_between(3, 18)
+    end
+
+    it "has a dice property with a length equal to number of dice" do
+      expect(dice_set.dice.length).to eq(3)
+    end
+
+    it "has elements in dice that are all Die objects" do
+      expect(dice_set.dice).to all(be_a(NerdDice::Die))
+    end
+  end
+
+  context "with one die and instantiation options" do
+    let(:one_die_with_options) { described_class.new(12, **dice_options) }
+
+    it "sets the number of sides from the first argument" do
+      expect(one_die_with_options.number_of_sides).to eq(12)
+    end
+
+    it "has the default number of dice equal to 1" do
+      expect(one_die_with_options.number_of_dice).to eq(1)
+    end
+
+    it "applies the randomization technique from options" do
+      expect(one_die_with_options.randomization_technique).to eq(:randomized)
+    end
+
+    it "applies the provided foreground_color of #FF0000" do
+      expect(one_die_with_options.foreground_color).to eq("#FF0000")
+    end
+
+    it "applies the provided background_color of #FFFFFF" do
+      expect(one_die_with_options.background_color).to eq("#FFFFFF")
+    end
+
+    it "applies the provided damage_type of fire" do
+      expect(one_die_with_options.damage_type).to eq("fire")
+    end
+
+    it "has a total between 1 and number of sides plus bonus" do
+      # includes bonus
+      expect(one_die_with_options.total).to be_between(6, 17)
+    end
+
+    it "has a dice property with a length of 1" do
+      expect(one_die_with_options.dice.length).to eq(1)
+    end
+
+    it "has an element in dice that is a Die object" do
+      expect(one_die_with_options.dice[0]).to be_a(NerdDice::Die)
+    end
+
+    it "applies randomization_technique to die object" do
+      die = one_die_with_options.dice[0]
+      expect(die.randomization_technique).to eq(:randomized)
+    end
+
+    it "applies foreground_color to die object" do
+      die = one_die_with_options.dice[0]
+      expect(die.foreground_color).to eq("#FF0000")
+    end
+
+    it "applies background_color to die object" do
+      die = one_die_with_options.dice[0]
+      expect(die.background_color).to eq("#FFFFFF")
+    end
+
+    it "applies damage_type to die object" do
+      die = one_die_with_options.dice[0]
+      expect(die.damage_type).to eq("fire")
+    end
+  end
+
+  context "with three dice and instantiation options" do
+    let(:three_dice_with_options) { described_class.new(6, 3, **dice_options) }
+
+    it "sets the number of sides from the first argument" do
+      expect(three_dice_with_options.number_of_sides).to eq(6)
+    end
+
+    it "sets the number of dice from the second argument" do
+      expect(three_dice_with_options.number_of_dice).to eq(3)
+    end
+
+    it "applies the randomization technique from options" do
+      expect(three_dice_with_options.randomization_technique).to eq(:randomized)
+    end
+
+    it "applies the provided foreground_color of #FF0000" do
+      expect(three_dice_with_options.foreground_color).to eq("#FF0000")
+    end
+
+    it "applies the provided background_color of #FFFFFF" do
+      expect(three_dice_with_options.background_color).to eq("#FFFFFF")
+    end
+
+    it "applies the provided damage_type of fire" do
+      expect(three_dice_with_options.damage_type).to eq("fire")
+    end
+
+    it "has a total between number of dice and dice times sides plus bonus" do
+      # includes bonus
+      expect(three_dice_with_options.total).to be_between(8, 23)
+    end
+
+    it "has a dice property with a length equal to number of dice" do
+      expect(three_dice_with_options.dice.length).to eq(3)
+    end
+
+    it "has elements in dice that are all Die objects" do
+      expect(three_dice_with_options.dice).to all(be_a(NerdDice::Die))
+    end
+
+    it "applies randomization_technique to all dice" do
+      three_dice_with_options.dice.each do |die|
+        expect(die.randomization_technique).to eq(:randomized)
+      end
+    end
+
+    it "applies foreground_color to all dice" do
+      three_dice_with_options.dice.each do |die|
+        expect(die.foreground_color).to eq("#FF0000")
+      end
+    end
+
+    it "applies background_color to all dice" do
+      three_dice_with_options.dice.each do |die|
+        expect(die.background_color).to eq("#FFFFFF")
+      end
+    end
+
+    it "applies damage_type to to all dice" do
+      three_dice_with_options.dice.each do |die|
+        expect(die.damage_type).to eq("fire")
+      end
+    end
+  end
+
+  describe "error handling" do
+    it "raises error if bad randomization_technique provided" do
+      expect { described_class.new(6, 3, randomization_technique: :invalid) }.to raise_error(
+        NerdDice::Error, "randomization_technique must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
+      )
+    end
+
+    it "raises error if bad bonus provided" do
+      expect { described_class.new(6, 3, bonus: :flump) }.to raise_error(
+        ArgumentError, "Bonus must be a value that responds to :to_i"
+      )
+    end
+  end
+end

--- a/spec/nerd_dice/dice_set_spec.rb
+++ b/spec/nerd_dice/dice_set_spec.rb
@@ -252,4 +252,79 @@ RSpec.describe NerdDice::DiceSet do
       expect { dice.reroll_all }.to change(dice[2], :value)
     end
   end
+
+  describe "highest and with_advantage methods" do
+    before { NerdDice.refresh_seed!(randomization_technique: :random_rand, random_rand_seed: 24_601) }
+
+    let(:dice_4d6) { described_class.new 6, 4, randomization_technique: :random_rand }
+    let(:dice_2d20) { described_class.new 20, 2, randomization_technique: :random_rand }
+    let(:dice_d100) { described_class.new 100, randomization_technique: :random_rand }
+
+    it "returns self" do
+      expect(dice_4d6.highest(2)).to be_a(described_class)
+    end
+
+    it "eliminates only the lowest die if no argument" do
+      # a 17 and a 19
+      expect(dice_2d20.highest.total).to eq(19)
+    end
+
+    it "returns the highest n of the dice" do
+      # 3, 1, 4, 1
+      expect(dice_4d6.highest(3).total).to eq(8)
+    end
+
+    it "aliases highest as with_advantage" do
+      # 3, 1, 4, 1
+      expect(dice_4d6.with_advantage(3).total).to eq(8)
+    end
+
+    it "returns all dice if the argument matches number_of_dice" do
+      puts "d100 #{dice_d100.total}"
+      expect(dice_d100.highest(1).total).to eq(dice_d100.total)
+    end
+
+    it "raises error if the argument exceeds the number_of_dice" do
+      expect { dice_4d6.highest(5) }.to raise_error(
+        ArgumentError, "Argument cannot exceed number of dice"
+      )
+    end
+  end
+
+  describe "lowest and with_disadvantage methods" do
+    before { NerdDice.refresh_seed!(randomization_technique: :random_rand, random_rand_seed: 24_601) }
+
+    let(:dice_4d6) { described_class.new 6, 4, randomization_technique: :random_rand }
+    let(:dice_2d20) { described_class.new 20, 2, randomization_technique: :random_rand }
+    let(:dice_d100) { described_class.new 100, randomization_technique: :random_rand }
+
+    it "returns self" do
+      expect(dice_4d6.lowest(2)).to be_a(described_class)
+    end
+
+    it "eliminates only the highest die if no argument" do
+      # a 17 and a 19
+      expect(dice_2d20.lowest.total).to eq(17)
+    end
+
+    it "returns the lowest n of the dice" do
+      # 3, 1, 4, 1
+      expect(dice_4d6.lowest(3).total).to eq(5)
+    end
+
+    it "aliases lowest as with_disadvantage" do
+      # 3, 1, 4, 1
+      expect(dice_4d6.with_disadvantage(3).total).to eq(5)
+    end
+
+    it "returns all dice if the argument matches number_of_dice" do
+      expect(dice_d100.lowest.total).to eq(dice_d100.total)
+    end
+
+    it "raises error if the argument exceeds the number_of_dice" do
+      expect { dice_4d6.lowest(5) }.to raise_error(
+        ArgumentError, "Argument cannot exceed number of dice"
+      )
+    end
+  end
 end

--- a/spec/nerd_dice/dice_set_spec.rb
+++ b/spec/nerd_dice/dice_set_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe NerdDice::DiceSet do
     end
 
     it "has a dice property with a length of 1" do
-      expect(one_die.dice.length).to eq(1)
+      expect(one_die.length).to eq(1)
     end
 
     it "has an element in dice that is a Die object" do
-      expect(one_die.dice[0]).to be_a(NerdDice::Die)
+      expect(one_die[0]).to be_a(NerdDice::Die)
     end
   end
 
@@ -83,11 +83,11 @@ RSpec.describe NerdDice::DiceSet do
     end
 
     it "has a dice property with a length equal to number of dice" do
-      expect(dice_set.dice.length).to eq(3)
+      expect(dice_set.length).to eq(3)
     end
 
     it "has elements in dice that are all Die objects" do
-      expect(dice_set.dice).to all(be_a(NerdDice::Die))
+      expect(dice_set).to all(be_a(NerdDice::Die))
     end
   end
 
@@ -124,30 +124,30 @@ RSpec.describe NerdDice::DiceSet do
     end
 
     it "has a dice property with a length of 1" do
-      expect(one_die_with_options.dice.length).to eq(1)
+      expect(one_die_with_options.length).to eq(1)
     end
 
     it "has an element in dice that is a Die object" do
-      expect(one_die_with_options.dice[0]).to be_a(NerdDice::Die)
+      expect(one_die_with_options[0]).to be_a(NerdDice::Die)
     end
 
     it "applies randomization_technique to die object" do
-      die = one_die_with_options.dice[0]
+      die = one_die_with_options[0]
       expect(die.randomization_technique).to eq(:randomized)
     end
 
     it "applies foreground_color to die object" do
-      die = one_die_with_options.dice[0]
+      die = one_die_with_options[0]
       expect(die.foreground_color).to eq("#FF0000")
     end
 
     it "applies background_color to die object" do
-      die = one_die_with_options.dice[0]
+      die = one_die_with_options[0]
       expect(die.background_color).to eq("#FFFFFF")
     end
 
     it "applies damage_type to die object" do
-      die = one_die_with_options.dice[0]
+      die = one_die_with_options[0]
       expect(die.damage_type).to eq("fire")
     end
   end
@@ -185,33 +185,33 @@ RSpec.describe NerdDice::DiceSet do
     end
 
     it "has a dice property with a length equal to number of dice" do
-      expect(three_dice_with_options.dice.length).to eq(3)
+      expect(three_dice_with_options.length).to eq(3)
     end
 
     it "has elements in dice that are all Die objects" do
-      expect(three_dice_with_options.dice).to all(be_a(NerdDice::Die))
+      expect(three_dice_with_options).to all(be_a(NerdDice::Die))
     end
 
     it "applies randomization_technique to all dice" do
-      three_dice_with_options.dice.each do |die|
+      three_dice_with_options.each do |die|
         expect(die.randomization_technique).to eq(:randomized)
       end
     end
 
     it "applies foreground_color to all dice" do
-      three_dice_with_options.dice.each do |die|
+      three_dice_with_options.each do |die|
         expect(die.foreground_color).to eq("#FF0000")
       end
     end
 
     it "applies background_color to all dice" do
-      three_dice_with_options.dice.each do |die|
+      three_dice_with_options.each do |die|
         expect(die.background_color).to eq("#FFFFFF")
       end
     end
 
     it "applies damage_type to to all dice" do
-      three_dice_with_options.dice.each do |die|
+      three_dice_with_options.each do |die|
         expect(die.damage_type).to eq("fire")
       end
     end
@@ -228,6 +228,28 @@ RSpec.describe NerdDice::DiceSet do
       expect { described_class.new(6, 3, bonus: :flump) }.to raise_error(
         ArgumentError, "Bonus must be a value that responds to :to_i"
       )
+    end
+  end
+
+  describe "the reroll_all method" do
+    before { NerdDice.refresh_seed!(randomization_technique: :random_rand, random_rand_seed: 1337) }
+
+    let(:dice) { described_class.new 6, 3, randomization_technique: :random_rand }
+
+    it "changes the total" do
+      expect { dice.reroll_all }.to change(dice, :total)
+    end
+
+    it "changes the first die" do
+      expect { dice.reroll_all }.to change(dice[0], :value)
+    end
+
+    it "changes the second die" do
+      expect { dice.reroll_all }.to change(dice[1], :value)
+    end
+
+    it "changes the third die" do
+      expect { dice.reroll_all }.to change(dice[2], :value)
     end
   end
 end

--- a/spec/nerd_dice/die_spec.rb
+++ b/spec/nerd_dice/die_spec.rb
@@ -12,12 +12,16 @@ RSpec.describe NerdDice::Die do
       expect(die.generator_override).to be_nil
     end
 
-    it "has expected default foreground_color of #FFFFFF" do
-      expect(die.foreground_color).to eq("#FFFFFF")
+    it "has expected default foreground_color of #DDDDDD" do
+      expect(die.foreground_color).to eq("#DDDDDD")
     end
 
-    it "has expected default background_color of #0000FF" do
-      expect(die.background_color).to eq("#0000FF")
+    it "has expected default background_color of #0000DD" do
+      expect(die.background_color).to eq("#0000DD")
+    end
+
+    it "has a damage_type of nil" do
+      expect(die.damage_type).to be_nil
     end
 
     it "has a value between 1 and number of sides" do
@@ -30,23 +34,28 @@ RSpec.describe NerdDice::Die do
       described_class.new(12,
                           generator_override: :randomized,
                           foreground_color: "#FF0000",
-                          background_color: "#FFFFFF")
+                          background_color: "#FFFFFF",
+                          damage_type: "fire")
     end
 
     it "sets the number of sides from the first argument" do
       expect(die_with_options.number_of_sides).to eq(12)
     end
 
-    it "has applies the generator_override from options" do
+    it "applies the generator_override from options" do
       expect(die_with_options.generator_override).to eq(:randomized)
     end
 
-    it "has applies the provided foreground_color of #FF0000" do
+    it "applies the provided foreground_color of #FF0000" do
       expect(die_with_options.foreground_color).to eq("#FF0000")
     end
 
-    it "has expected default background_color of #FFFFFF" do
+    it "applies the provided background_color of #FFFFFF" do
       expect(die_with_options.background_color).to eq("#FFFFFF")
+    end
+
+    it "applies the provided damage_type of fire" do
+      expect(die_with_options.damage_type).to eq("fire")
     end
 
     it "has a value between 1 and number of sides" do
@@ -90,13 +99,10 @@ RSpec.describe NerdDice::Die do
   end
 
   describe "comparable_methods" do
-    before do
-      NerdDice.configuration.randomization_technique = :random_rand
-      NerdDice.refresh_seed!(random_rand_new_seed: 1337)
-    end
+    before { NerdDice.refresh_seed!(randomization_technique: :random_rand, random_rand_seed: 1337) }
 
-    let(:die1) { described_class.new 6 }
-    let(:die2) { described_class.new 100 }
+    let(:die1) { described_class.new 6, generator_override: :random_rand }
+    let(:die2) { described_class.new 100, generator_override: :random_rand }
     let(:die3) { described_class.new 1 }
     let(:die4) { described_class.new 1 }
 

--- a/spec/nerd_dice/die_spec.rb
+++ b/spec/nerd_dice/die_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe NerdDice::Die do
     it "has a value between 1 and number of sides" do
       expect(die.value).to be_between(1, 20)
     end
+
+    it "has a included_in_total? of true" do
+      expect(die.is_included_in_total).to be(true)
+    end
   end
 
   context "with instantiation options" do
@@ -61,6 +65,10 @@ RSpec.describe NerdDice::Die do
     it "has a value between 1 and number of sides" do
       expect(die_with_options.value).to be_between(1, 12)
     end
+
+    it "has a included_in_total? of true" do
+      expect(die.is_included_in_total).to be(true)
+    end
   end
 
   describe "roll method" do
@@ -87,6 +95,19 @@ RSpec.describe NerdDice::Die do
     it "returns the new value" do
       roll_value = die.roll
       expect(roll_value).to eq(die.value)
+    end
+  end
+
+  describe "setting included_in_total? attribute" do
+    it "can be set to false" do
+      die.is_included_in_total = false
+      expect(die.included_in_total?).to be(false)
+    end
+
+    it "can be set to true" do
+      die.is_included_in_total = false
+      die.is_included_in_total = true
+      expect(die.included_in_total?).to be(true)
     end
   end
 

--- a/spec/nerd_dice/die_spec.rb
+++ b/spec/nerd_dice/die_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe NerdDice::Die do
+  subject(:die) { described_class.new(20) }
+
+  context "with instantiation options" do
+    it "sets the number of sides from the first argument" do
+      expect(die.number_of_sides).to eq(20)
+    end
+
+    it "has expected default generator_override of nil" do
+      expect(die.generator_override).to be_nil
+    end
+
+    it "has expected default foreground_color of #FFFFFF" do
+      expect(die.foreground_color).to eq("#FFFFFF")
+    end
+
+    it "has expected default background_color of #0000FF" do
+      expect(die.background_color).to eq("#0000FF")
+    end
+
+    it "has a value between 1 and number of sides" do
+      expect(die.value).to be_between(1, 20)
+    end
+  end
+
+  context "without instantiation options" do
+    let(:die_with_options) do
+      described_class.new(12,
+                          generator_override: :randomized,
+                          foreground_color: "#FF0000",
+                          background_color: "#FFFFFF")
+    end
+
+    it "sets the number of sides from the first argument" do
+      expect(die_with_options.number_of_sides).to eq(12)
+    end
+
+    it "has applies the generator_override from options" do
+      expect(die_with_options.generator_override).to eq(:randomized)
+    end
+
+    it "has applies the provided foreground_color of #FF0000" do
+      expect(die_with_options.foreground_color).to eq("#FF0000")
+    end
+
+    it "has expected default background_color of #FFFFFF" do
+      expect(die_with_options.background_color).to eq("#FFFFFF")
+    end
+
+    it "has a value between 1 and number of sides" do
+      expect(die_with_options.value).to be_between(1, 20)
+    end
+  end
+
+  describe "roll method" do
+    let(:original_value) { die.value }
+
+    # rubocop:disable RSpec/ExampleLength
+    it "replaces the value of the die" do
+      changed = false
+      5.times do
+        die.roll
+        changed = true if die.value != original_value
+      end
+      expect(changed).to eq(true)
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it "has the correct range" do
+      5.times do
+        die.roll
+        expect(die.value).to be_between(1, 20)
+      end
+    end
+
+    it "returns the new value" do
+      roll_value = die.roll
+      expect(roll_value).to eq(die.value)
+    end
+  end
+
+  describe "error handling" do
+    it "raises error if bad generator_override provided" do
+      expect { described_class.new(6, generator_override: :invalid) }.to raise_error(
+        NerdDice::Error, "generator_override must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
+      )
+    end
+  end
+end

--- a/spec/nerd_dice/die_spec.rb
+++ b/spec/nerd_dice/die_spec.rb
@@ -3,13 +3,13 @@
 RSpec.describe NerdDice::Die do
   subject(:die) { described_class.new(20) }
 
-  context "with instantiation options" do
+  context "without instantiation options" do
     it "sets the number of sides from the first argument" do
       expect(die.number_of_sides).to eq(20)
     end
 
-    it "has expected default generator_override of nil" do
-      expect(die.generator_override).to be_nil
+    it "has expected default randomization_technique of nil" do
+      expect(die.randomization_technique).to be_nil
     end
 
     it "has expected default foreground_color of #DDDDDD" do
@@ -29,10 +29,10 @@ RSpec.describe NerdDice::Die do
     end
   end
 
-  context "without instantiation options" do
+  context "with instantiation options" do
     let(:die_with_options) do
       described_class.new(12,
-                          generator_override: :randomized,
+                          randomization_technique: :randomized,
                           foreground_color: "#FF0000",
                           background_color: "#FFFFFF",
                           damage_type: "fire")
@@ -42,8 +42,8 @@ RSpec.describe NerdDice::Die do
       expect(die_with_options.number_of_sides).to eq(12)
     end
 
-    it "applies the generator_override from options" do
-      expect(die_with_options.generator_override).to eq(:randomized)
+    it "applies the randomization_technique from options" do
+      expect(die_with_options.randomization_technique).to eq(:randomized)
     end
 
     it "applies the provided foreground_color of #FF0000" do
@@ -59,7 +59,7 @@ RSpec.describe NerdDice::Die do
     end
 
     it "has a value between 1 and number of sides" do
-      expect(die_with_options.value).to be_between(1, 20)
+      expect(die_with_options.value).to be_between(1, 12)
     end
   end
 
@@ -91,9 +91,9 @@ RSpec.describe NerdDice::Die do
   end
 
   describe "error handling" do
-    it "raises error if bad generator_override provided" do
-      expect { described_class.new(6, generator_override: :invalid) }.to raise_error(
-        NerdDice::Error, "generator_override must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
+    it "raises error if bad randomization_technique provided" do
+      expect { described_class.new(6, randomization_technique: :invalid) }.to raise_error(
+        NerdDice::Error, "randomization_technique must be one of #{NerdDice::RANDOMIZATION_TECHNIQUES.join(', ')}"
       )
     end
   end
@@ -101,8 +101,8 @@ RSpec.describe NerdDice::Die do
   describe "comparable_methods" do
     before { NerdDice.refresh_seed!(randomization_technique: :random_rand, random_rand_seed: 1337) }
 
-    let(:die1) { described_class.new 6, generator_override: :random_rand }
-    let(:die2) { described_class.new 100, generator_override: :random_rand }
+    let(:die1) { described_class.new 6, randomization_technique: :random_rand }
+    let(:die2) { described_class.new 100, randomization_technique: :random_rand }
     let(:die3) { described_class.new 1 }
     let(:die4) { described_class.new 1 }
 

--- a/spec/nerd_dice/die_spec.rb
+++ b/spec/nerd_dice/die_spec.rb
@@ -88,4 +88,32 @@ RSpec.describe NerdDice::Die do
       )
     end
   end
+
+  describe "comparable_methods" do
+    before do
+      NerdDice.configuration.randomization_technique = :random_rand
+      NerdDice.refresh_seed!(random_rand_new_seed: 1337)
+    end
+
+    let(:die1) { described_class.new 6 }
+    let(:die2) { described_class.new 100 }
+    let(:die3) { described_class.new 1 }
+    let(:die4) { described_class.new 1 }
+
+    it "has working > method" do
+      expect(die2 > die1).to be(true)
+    end
+
+    it "has working < method" do
+      expect(die1 < die2).to be(true)
+    end
+
+    it "has working == method for unequal" do
+      expect(die1 == die2).to be(false)
+    end
+
+    it "has working == method for equal" do
+      expect(die3 == die4).to be(true)
+    end
+  end
 end

--- a/spec/nerd_dice/roll_dice_spec.rb
+++ b/spec/nerd_dice/roll_dice_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "support/nerd_dice_helper"
+
+RSpec.configure do |config|
+  config.include NerdDiceHelper
+end
+
+RSpec.describe NerdDice, ".roll_dice" do
+  let(:sample_size) { 20 }
+
+  context "with no options" do
+    it "returns a DiceSet" do
+      expect(described_class.roll_dice(6)).to be_a(NerdDice::DiceSet)
+    end
+
+    it "calculates the dice total correctly for a single die" do
+      sample_size.times do
+        result = described_class.roll_dice(6).total
+        expect(result).to be_between(1, 6)
+      end
+    end
+
+    it "calculates the dice total correctly for a multiple dice" do
+      sample_size.times do
+        result = described_class.roll_dice(6, 3).total
+        expect(result).to be_between(3, 18)
+      end
+    end
+  end
+
+  context "with bonus option" do
+    it "returns a DiceSet" do
+      expect(described_class.roll_dice(6, 3, bonus: 2)).to be_a(NerdDice::DiceSet)
+    end
+
+    it "allows method chaining" do
+      result = described_class.roll_dice(6, 3, bonus: 2).with_advantage(2).total
+      expect(result).to be_between(4, 14)
+    end
+
+    it "calculates with a positive bonus correctly" do
+      sample_size.times do
+        result = described_class.roll_dice(6, 3, bonus: 2).total
+        expect(result).to be_between(5, 20)
+      end
+    end
+
+    it "calculates with a positive bonus correctly with a Float" do
+      sample_size.times do
+        result = described_class.roll_dice(6, 3, bonus: 2.9).total
+        expect(result).to be_between(5, 20)
+      end
+    end
+
+    it "calculates with a positive bonus correctly with a String" do
+      sample_size.times do
+        result = described_class.roll_dice(6, 3, bonus: "2.7").total
+        expect(result).to be_between(5, 20)
+      end
+    end
+
+    it "calculates with a zero bonus correctly" do
+      sample_size.times do
+        result = described_class.roll_dice(6, 3, bonus: 0).total
+        expect(result).to be_between(3, 18)
+      end
+    end
+
+    it "calculates with a negative penalty correctly" do
+      sample_size.times do
+        result = described_class.roll_dice(6, 3, bonus: -5).total
+        expect(result).to be_between(-2, 13)
+      end
+    end
+
+    it "calculates with a negative penalty correctly with a Float" do
+      sample_size.times do
+        result = described_class.roll_dice(6, 3, bonus: -5.7).total
+        expect(result).to be_between(-2, 13)
+      end
+    end
+
+    it "calculates with a negative penalty correctly with a String" do
+      sample_size.times do
+        result = described_class.roll_dice(6, 3, bonus: "-5.992").total
+        expect(result).to be_between(-2, 13)
+      end
+    end
+
+    it "ignores non-integer bonus correctly" do
+      sample_size.times do
+        result = described_class.roll_dice(6, 3, bonus: "foo").total
+        expect(result).to be_between(3, 18)
+      end
+    end
+
+    it "handles one die" do
+      sample_size.times do
+        result = described_class.roll_dice(6, bonus: 2).total
+        expect(result).to be_between(2, 8)
+      end
+    end
+
+    it "raises an error if bonus does not respond to .to_i" do
+      expect { described_class.roll_dice(6, bonus: Kernel) }.to raise_error(
+        ArgumentError, "Bonus must be a value that responds to :to_i"
+      )
+    end
+  end
+
+  context "with randomization_technique option" do
+    let(:option_gen) { get_different_technique(described_class.configuration.randomization_technique) }
+
+    it "returns a DiceSet" do
+      expect(described_class.roll_dice(20, randomization_technique: option_gen)).to be_a(NerdDice::DiceSet)
+    end
+
+    it "sets the generator" do
+      option_result = described_class.roll_dice(20, randomization_technique: option_gen).randomization_technique
+      expect(option_result).to eq(option_gen)
+    end
+
+    it "uses the specified option when provided" do
+      sample_size.times do
+        result = described_class.roll_dice(20, randomization_technique: option_gen).total
+        expect(result).to be_between(1, 20)
+      end
+    end
+
+    it "handles nil" do
+      sample_size.times do
+        result = described_class.roll_dice(20, randomization_technique: nil).total
+        expect(result).to be_between(1, 20)
+      end
+    end
+
+    it "calculates the bonus correctly and uses generator with both options" do
+      sample_size.times do
+        result = described_class.roll_dice(6, 3, randomization_technique: option_gen, bonus: 3).total
+        expect(result).to be_between(6, 21)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `Die` and `DiceSet` classes to `NerdDice` module. These allow you to instantiate `Die` objects individually (by using `Die.new`) or as a collection (by using `DiceSet.new`). Also added in `roll_dice` method to the `NerdDice` module that makes use of the `DiceSet` and `Die` objects with a similar interface to the `total_dice` method and added in a `SetsRandomizationTechnique` module that is mixed in by both the `Die` and `DiceSet` objects. Added in configuration options to `NerdDice::Configuration` that allow users to specify foreground and background colors for dice with defaults set as constants. (Functionality for doing anything with those colors other than getting and setting them hasn\'t been implemented yet.)