### PR TITLE
Refactor rubocop.yml to enable by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,11 @@
+# RuboCop configuration file for NerdDice gem
+#
+# This is the RuboCop configuration for the gem. By default new cops are enabled
+# by default when the RuboCop gems are updated in the bundle. Before the would
+# show up as warnings until they were added to the configuration file. Now they
+# will be enabled by default, and a case-by-case descision can be made whether
+# to exclude new violations in the configuration explicitly or update the
+# codebase to the gem to conform to the new standard.
 require:
     - rubocop-performance
     - rubocop-rake
@@ -8,14 +16,12 @@ AllCops:
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   #DisabledByDefault: true
+
+  # New cops are now enabled by default as of 2023-02-20
+  NewCops: enable
   Exclude:
     - '**/templates/**/*'
     - '**/vendor/**/*'
-    - 'node_modules/**/*'
-
-Performance:
-  Exclude:
-    - '**/test/**/*'
 
 # Prefer &&/|| over and/or.
 Style/AndOr:
@@ -111,15 +117,6 @@ Style/MethodDefParentheses:
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always
-  Exclude:
-    - 'actionview/test/**/*.builder'
-    - 'actionview/test/**/*.ruby'
-    - 'actionpack/test/**/*.builder'
-    - 'actionpack/test/**/*.ruby'
-    - 'activestorage/db/migrate/**/*.rb'
-    - 'activestorage/db/update_migrate/**/*.rb'
-    - 'actionmailbox/db/migrate/**/*.rb'
-    - 'actiontext/db/migrate/**/*.rb'
 
 Style/RedundantFreeze:
   Enabled: true
@@ -191,30 +188,6 @@ Lint/UselessAssignment:
 Lint/DeprecatedClassMethods:
   Enabled: true
 
-Lint/DuplicateBranch: # (new in 1.3)
-  Enabled: true
-
-Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
-  Enabled: true
-
-Lint/EmptyBlock: # (new in 1.1)
-  Enabled: true
-
-Lint/EmptyClass: # (new in 1.3)
-  Enabled: true
-
-Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
-  Enabled: true
-
-Lint/ToEnumArguments: # (new in 1.1)
-  Enabled: true
-
-Lint/UnexpectedBlockArity: # (new in 1.5)
-  Enabled: true
-
-Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
-  Enabled: true
-
 Style/ParenthesesAroundCondition:
   Enabled: true
 
@@ -236,27 +209,6 @@ Style/ColonMethodCall:
 Style/TrivialAccessors:
   Enabled: true
 
-Style/ArgumentsForwarding: # (new in 1.1)
-  Enabled: true
-
-Style/CollectionCompact: # (new in 1.2)
-  Enabled: true
-
-Style/DocumentDynamicEvalDefinition: # (new in 1.1)
-  Enabled: true
-
-Style/NegatedIfElseCondition: # (new in 1.2)
-  Enabled: true
-
-Style/NilLambda: # (new in 1.3)
-  Enabled: true
-
-Style/RedundantArgument: # (new in 1.4)
-  Enabled: true
-
-Style/SwapValues: # (new in 1.1)
-  Enabled: true
-
 Performance/FlatMap:
   Enabled: true
 
@@ -275,167 +227,9 @@ Performance/RegexpMatch:
 Performance/UnfreezeString:
   Enabled: true
 
-Performance/AncestorsInclude: # (new in 1.7)
-  Enabled: true
-
-Performance/BigDecimalWithNumericArgument: # (new in 1.7)
-  Enabled: true
-
-Performance/BlockGivenWithExplicitBlock: # (new in 1.9)
-  Enabled: true
-
-Performance/CollectionLiteralInLoop: # (new in 1.8)
-  Enabled: true
-
-Performance/ConstantRegexp: # (new in 1.9)
-  Enabled: true
-
-Performance/MethodObjectAsBlock: # (new in 1.9)
-  Enabled: true
-
-Performance/RedundantSortBlock: # (new in 1.7)
-  Enabled: true
-
-Performance/RedundantStringChars: # (new in 1.7)
-  Enabled: true
-
-Performance/ReverseFirst: # (new in 1.7)
-  Enabled: true
-
-Performance/SortReverse: # (new in 1.7)
-  Enabled: true
-
-Performance/Squeeze: # (new in 1.7)
-  Enabled: true
-
-Performance/StringInclude: # (new in 1.7)
-  Enabled: true
-
-Performance/Sum: # (new in 1.8)
-  Enabled: true
-
-Layout/SpaceBeforeBrackets: # (new in 1.7)
-  Enabled: true
-
-Lint/AmbiguousAssignment: # (new in 1.7)
-  Enabled: true
-
-Lint/DeprecatedConstants: # (new in 1.8)
-  Enabled: true
-
-Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
-  Enabled: true
-
-Lint/RedundantDirGlobSort: # (new in 1.8)
-  Enabled: true
-
-Style/EndlessMethod: # (new in 1.8)
-  Enabled: true
-
-Style/HashExcept: # (new in 1.7)
-  Enabled: true
-
-# Added 2021-08-14
-Gemspec/DateAssignment: # (new in 1.10)
-  Enabled: true
-
-Layout/LineEndStringConcatenationIndentation: # (new in 1.18)
-  Enabled: true
-
-Lint/EmptyInPattern: # (new in 1.16)
-  Enabled: true
-
-Lint/NumberedParameterAssignment: # (new in 1.9)
-  Enabled: true
-
-Lint/OrAssignmentToConstant: # (new in 1.9)
-  Enabled: true
-
-Lint/SymbolConversion: # (new in 1.9)
-  Enabled: true
-
-Lint/TripleQuotes: # (new in 1.9)
-  Enabled: true
-
-Naming/InclusiveLanguage: # (new in 1.18)
-  Enabled: false
-
-Style/HashConversion: # (new in 1.10)
-  Enabled: true
-
-Style/IfWithBooleanLiteralBranches: # (new in 1.9)
-  Enabled: true
-
-Style/InPatternThen: # (new in 1.16)
-  Enabled: true
-
-Style/MultilineInPatternThen: # (new in 1.16)
-  Enabled: true
-
-Style/QuotedSymbols: # (new in 1.16)
-  Enabled: true
-
-Style/StringChars: # (new in 1.12)
-  Enabled: true
-
-Performance/MapCompact: # (new in 1.11)
-  Enabled: true
-
-Performance/RedundantEqualityComparisonBlock: # (new in 1.10)
-  Enabled: true
-
-Performance/RedundantSplitRegexpArgument: # (new in 1.10)
-  Enabled: true
-
-RSpec/IdenticalEqualityAssertion: # (new in 2.4)
-  Enabled: true
-
-RSpec/Rails/AvoidSetupHook: # (new in 2.4)
-  Enabled: true
-
 RSpec/MessageSpies:
   EnforcedStyle: receive
 
-Lint/AmbiguousRange: # new in 1.19
-  Enabled: true
-Style/RedundantSelfAssignmentBranch: # new in 1.19
-  Enabled: true
-
-Lint/AmbiguousOperatorPrecedence: # new in 1.21
-  Enabled: true
-Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
-  Enabled: true
-Lint/RequireRelativeSelfPath: # new in 1.22
-  Enabled: true
-Security/IoMethods: # new in 1.22
-  Enabled: true
-Style/NumberedParameters: # new in 1.22
-  Enabled: true
-Style/NumberedParametersLimit: # new in 1.22
-  Enabled: true
-Style/SelectByRegexp: # new in 1.22
-  Enabled: true
-RSpec/ExcessiveDocstringSpacing: # new in 2.5
-  Enabled: true
-RSpec/SubjectDeclaration: # new in 2.5
-  Enabled: true
-Gemspec/RequireMFA: # new in 1.23
-  Enabled: true
-Lint/UselessRuby2Keywords: # new in 1.23
-  Enabled: true
-Naming/BlockForwarding: # new in 1.24
-  Enabled: true
-Style/FileRead: # new in 1.24
-  Enabled: true
-Style/FileWrite: # new in 1.24
-  Enabled: true
-Style/MapToHash: # new in 1.24
-  Enabled: true
-Style/OpenStructUse: # new in 1.23
-  Enabled: true
-Performance/ConcurrentMonotonicTime: # new in 1.12
-  Enabled: true
-Performance/StringIdentifierArgument: # new in 1.13
-  Enabled: true
-RSpec/FactoryBot/SyntaxMethods: # new in 2.7
-  Enabled: true
+# Disable inclusive language cop. None of RuboCop's business
+Naming/InclusiveLanguage:
+  Enabled: false


### PR DESCRIPTION
Refactor rubocop.yml to enable new cops by default. This allows for the default cops to all run and add new cops when they become available by default. If any new cops come into effect that do not align with the current style of the project, we can either modify the project to conform or disable in the config. This makes the configuration file lighter weight and easier to read and maintain.

Completes #43 Refactor rubocop.yml files to enable new cops and remove unnecessary config