### PR TITLE
Drop support for Ruby 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ require:
     - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   #DisabledByDefault: true

--- a/lib/nerd_dice/convenience_methods.rb
+++ b/lib/nerd_dice/convenience_methods.rb
@@ -78,10 +78,10 @@ module NerdDice
   #     roll_d20_with_advantage_lowest # will raise NameError using super method_missing
   #     total_4d6_lowest3_highest2 # will raise NameError using super method_missing
   module ConvenienceMethods
-    DIS = /_(with_disadvantage|lowest)/.freeze
-    ADV = /_(with_advantage|highest)/.freeze
-    MOD = /(_p(lus)?\d+|_m(inus)?\d+)/.freeze
-    OVERALL_REGEXP = /\A(roll|total)_\d*d\d+((#{ADV}|#{DIS})\d*)?#{MOD}?\z/.freeze
+    DIS = /_(with_disadvantage|lowest)/
+    ADV = /_(with_advantage|highest)/
+    MOD = /(_p(lus)?\d+|_m(inus)?\d+)/
+    OVERALL_REGEXP = /\A(roll|total)_\d*d\d+((#{ADV}|#{DIS})\d*)?#{MOD}?\z/
 
     # Override of method_missing
     # * Attempts to match pattern to the regular expression matching the methods

--- a/nerd_dice.gemspec
+++ b/nerd_dice.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   GEM_DESCRIPTION
   spec.homepage = "https://github.com/statelesscode/nerd_dice"
   spec.licenses = %w[Unlicense MIT]
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 

--- a/spec/nerd_dice/shared_examples/the_refresh_seed_method.rb
+++ b/spec/nerd_dice/shared_examples/the_refresh_seed_method.rb
@@ -42,8 +42,7 @@ RSpec.shared_examples "a specified random_rand seed" do
   before { execute_with_config(*config_vars) }
 
   it "matches supplied new random_rand value" do
-    random_rand = RUBY_VERSION.to_f < 3 ? Random::DEFAULT : Random
-    expect(random_rand.seed).to eq(RefreshSeedHelper::NEW_RANDOM_RAND_SEED)
+    expect(RefreshSeedHelper::NEW_RANDOM_RAND_SEED).to eq(Random.seed)
   end
 end
 


### PR DESCRIPTION
Normal support for Ruby 2.7 has ended. Security support ends on 2023-03-31, at which point that Ruby version will be end-of-life.

Instead of attempting to fix the failing build for RSpec in Ruby 2.7, determined the solution was to drop support for Ruby 2.7. After making the minimum version 3.0, there was some logic we were able to remove from a test class, and some redundant frezzes we were able to eliminate.

Circumvents #47 RSpec failing on Ruby 2.7. Investigate whether a workaround is available.